### PR TITLE
first stable release of connector_flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
-# example: dependency
-# - git clone https://github.com/OCA/webkit-tools -b ${VERSION} $HOME/webkit-tools
+  - git clone https://github.com/OCA/connector $HOME/connector -b 7.0
 
 script:
   - travis_run_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ install:
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
   - travis_install_nightly
   - git clone https://github.com/OCA/connector $HOME/connector -b 7.0
+  - pip install ftputil
+  - pip install xlrd
 
 script:
   - travis_run_tests

--- a/connector_flow/__init__.py
+++ b/connector_flow/__init__.py
@@ -1,0 +1,5 @@
+from . import impexp_task
+from . import file
+from . import chunk
+from . import wizard
+from . import task

--- a/connector_flow/__openerp__.py
+++ b/connector_flow/__openerp__.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Connector-based task flow for import/export',
+    'version': '0.1',
+    'description': """This module provides a minimal framework for common
+data import/export tasks based on the OpenERP Connector. Tasks like parsing
+and writing a CSV file or uploading a file to an FTP server can be chained
+into task flows.
+
+At the moment every flow must a have a unique start. One task can trigger
+several tasks.
+
+The module adds a new menu item "Import/Export" under the Connector top-level
+menu where tasks and task flows can be configured. Tasks can be run from
+the "Run Task" wizard. If a task needs a file as input, a file can be uploaded
+in the wizard.
+
+The *connector_flow_example_{ftp,product}* modules provide pre-configured
+demo flows.
+
+This module was definitely inspired by the works of Akretion (file_repository)
+and Camptocamp (connector_file).""",
+    'category': 'Connector',
+    'author': 'initOS GmbH & Co. KG',
+    'license': 'AGPL-3',
+    'website': 'http://www.initos.com',
+    'depends': [
+        'connector',
+        'fix_bug_1316948',
+    ],
+    'external_dependencies': {
+        'python': ['ftputil'],
+    },
+    'data': [
+        'impexp_task_view.xml',
+        'file_view.xml',
+        'chunk_view.xml',
+        'wizard/run_task_view.xml',
+        'security/ir.model.access.csv',
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/connector_flow/__openerp__.py
+++ b/connector_flow/__openerp__.py
@@ -39,7 +39,10 @@ The *connector_flow_example_{ftp,product}* modules provide pre-configured
 demo flows.
 
 This module was definitely inspired by the works of Akretion (file_repository)
-and Camptocamp (connector_file).""",
+and Camptocamp (connector_file).
+
+A very brief tutorial can be found at http://blog.initos.com/?p=1220
+""",
     'category': 'Connector',
     'author': 'initOS GmbH & Co. KG',
     'license': 'AGPL-3',

--- a/connector_flow/chunk.py
+++ b/connector_flow/chunk.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class imp_exp_chunk(orm.Model):
+    _name = 'impexp.chunk'
+    _description = 'Structured (parsed) data from a file' +\
+                   ' to be imported/exported'
+
+    _columns = {
+        'file_id': fields.many2one('impexp.file', 'File'),
+        'name': fields.char('Name', required=True),
+        'data': fields.text('Data', required=True),
+        'task_id': fields.related('file_id', 'task_id', 'Related Task'),
+        'state': fields.selection([('new', 'New'),
+                                   ('failed', 'Failed'),
+                                   ('done', 'Done')],
+                                  'State',
+                                  required=True),
+    }
+
+    _defaults = {
+        'state': 'new',
+    }

--- a/connector_flow/chunk_view.xml
+++ b/connector_flow/chunk_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="chunk_form_view">
+            <field name="name">impexp.chunk.form.view</field>
+            <field name="model">impexp.chunk</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Task Form" version="7.0" create='false'>
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name" readonly="1"/>
+                                <field name="data" attrs="{'readonly': [('state', 'in', ['failed', 'done'])]}"/>
+                            </group>
+                            <group>
+                                <field name="state" readonly="1"/>
+                            </group>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/connector_flow/file.py
+++ b/connector_flow/file.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class impexp_file(orm.Model):
+    _name = 'impexp.file'
+    _description = 'Wrapper for a file to be imported/exported'
+
+    _columns = {
+        'attachment_id': fields.many2one('ir.attachment', 'Attachment',
+                                         required=True),
+        'task_id': fields.many2one('impexp.task', 'Task', required=True),
+        'state': fields.selection([('new', 'New'),
+                                   ('failed', 'Failed'),
+                                   ('done', 'Done')],
+                                  'State',
+                                  required=True),
+    }
+
+    _defaults = {
+        'state': 'new',
+    }

--- a/connector_flow/file_view.xml
+++ b/connector_flow/file_view.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="file_tree">
+            <field name="name">impexp.file.tree</field>
+            <field name="model">impexp.file</field>
+            <field name="type">tree</field>
+            <field name="arch" type="xml">
+                <tree string="Task Tree">
+                    <field name="attachment_id"/>
+                    <field name="task_id"/>
+                    <field name="state"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="file_view_action">
+            <field name="name">Files</field>
+            <field name="res_model">impexp.file</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="file_tree"/>
+            <field name="target">current</field>
+        </record>
+
+        <menuitem id="menu_impexp_file"
+                  name="Files"
+                  parent="menu_impexp_root"
+                  action="file_view_action"/>
+
+    </data>
+</openerp>

--- a/connector_flow/impexp_task.py
+++ b/connector_flow/impexp_task.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.addons.connector.queue.job import job, related_action
+from openerp.addons.connector.session import ConnectorSession
+from ast import literal_eval
+
+
+def impexp_related_action(session, job):
+    # Redirect the call to OpenERP model
+    return session.pool.get('impexp.task') \
+        .related_action(session.cr, session.uid,
+                        job=job, context=session.context)
+
+
+@job
+@related_action(action=impexp_related_action)
+def run_task(session, model_name, ids, **kwargs):
+    return session.pool.get('impexp.task') \
+        .run_task(session.cr, session.uid, ids, **kwargs)
+
+
+class impexp_task_transition(orm.Model):
+    _name = 'impexp.task.transition'
+    _description = 'Transition between tasks'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return []
+
+    _columns = {
+        'task_from_id': fields.many2one('impexp.task',
+                                        'Output-producing Task'),
+        'task_to_id': fields.many2one('impexp.task',
+                                      'Input-consuming Task'),
+    }
+
+
+class impexp_task_flow(orm.Model):
+    _name = 'impexp.task.flow'
+    _description = 'A flow of tasks that are connected by transitions'
+
+    _columns = {
+        'name': fields.char('Name', required=True),
+        'task_ids': fields.one2many('impexp.task', 'flow_id',
+                                    'Tasks in Flow')
+    }
+
+
+class impexp_task(orm.Model):
+    _name = 'impexp.task'
+    _description = 'A wrapper class for an import/export task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return []
+
+    def _get_available_types(self, cr, uid, context=None):
+        return [('file', 'File'), ('chunk', 'Chunk')]
+
+    _columns = {
+        'name': fields.char('Name', required=True),
+        'task': fields.selection(_get_available_tasks, string='Task'),
+        'config': fields.text('Configuration'),
+        'last_start': fields.datetime('Starting Time of the Last Run'),
+        'last_finish': fields.datetime('Finishing Time of'
+                                       'the Last Successful Run'),
+        'max_retries': fields.integer('Maximal Number of Re-tries'
+                                      ' If Run Asynchronously',
+                                      required=True),
+        'flow_id': fields.many2one('impexp.task.flow', 'Task Flow'),
+        'transitions_out_ids': fields.one2many('impexp.task.transition',
+                                               'task_from_id',
+                                               'Outgoing Transitions'),
+        'transitions_in_ids': fields.one2many('impexp.task.transition',
+                                              'task_to_id',
+                                              'Incoming Transitions'),
+        'flow_start': fields.boolean('Start of a Task Flow'),
+    }
+
+    _defaults = {
+        'max_retries': 1,
+    }
+
+    def _check_unique_flow_start(self, cr, uid, ids, context=None):
+        """Check that there is at most one task that starts the
+           flow in a task flow"""
+        for task in self.browse(cr, uid, ids, context=context):
+            domain = [('flow_id', '=', task.flow_id.id),
+                      ('flow_start', '=', True)]
+            flow_start_ids = self.search(cr, uid, domain)
+            if len(flow_start_ids) > 1:
+                return False
+        return True
+
+    _constraints = [
+        (_check_unique_flow_start, 'The start of a task flow has to be unique',
+         ['flow_id', 'flow_start'])
+    ]
+
+    def _config(self, cr, uid, ids, context=None):
+        """Parse task configuration"""
+        config = self.read(cr, uid, ids, ['config'])[0]['config']
+        if config:
+            return literal_eval(config)
+        return {}
+
+    def do_run(self, cr, uid, task_ids, context=None, async=True, **kwargs):
+        if async:
+            method = run_task.delay
+            assert len(task_ids) == 1
+            task_data = self.read(cr, uid, task_ids[0],
+                                  ['name', 'max_retries'])
+            kwargs.update({'description': task_data['name'],
+                           'max_retries': task_data['max_retries']})
+        else:
+            method = run_task
+        result = method(ConnectorSession(cr, uid, context=context),
+                        self._name, task_ids, async=async, **kwargs)
+        # If we run asynchronously, we ignore the result
+        #  (which is the UUID of the job in the queue).
+        if not async:
+            return result
+
+    def do_run_flow(self, cr, uid, flow_id,
+                    context=None, async=True, **kwargs):
+        flow_obj = self.pool.get('impexp.task.flow')
+        flow = flow_obj.browse(cr, uid, flow_id)
+        task_id = False
+        for task in flow.task_ids:
+            if task.flow_start:
+                task_id = task.id
+        if not task_id:
+            raise Exception('Flow %d has no start' % flow_id)
+        return self.do_run(cr, uid, [task_id],
+                           context=context, async=True, **kwargs)
+
+    def get_task_instance(self, cr, uid, ids):
+        task_list = self.browse(cr, uid, ids)
+        assert len(task_list) == 1
+
+        task_method = task_list[0].task
+        task_class = getattr(self, task_method + '_class')()
+        return task_class(cr, uid, ids)
+
+    def run_task(self, cr, uid, ids, **kwargs):
+        task_instance = self.get_task_instance(cr, uid, ids)
+        config = self._config(cr, uid, ids)
+        return task_instance.run(config=config, **kwargs)
+
+    def related_action(self, cr, uid, job=None, **kwargs):
+        task_instance = self.get_task_instance(cr, uid, job.args[1])
+        return task_instance.related_action(job=job, **kwargs)

--- a/connector_flow/impexp_task_view.xml
+++ b/connector_flow/impexp_task_view.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <!-- impexp.task -->
+
+        <record model="ir.ui.view" id="task_tree">
+            <field name="name">impexp.task.tree</field>
+            <field name="model">impexp.task</field>
+            <field name="type">tree</field>
+            <field name="arch" type="xml">
+                <tree string="Task Tree">
+                    <field name="name"/>
+                    <field name="task"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="task_form">
+            <field name="name">impexp.task.form</field>
+            <field name="model">impexp.task</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Task Form" version="7.0">
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="task"/>
+                            <field name="max_retries"/>
+                            <field name="flow_id"/>
+                            <field name="flow_start"/>
+                            <field name="config"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- impexp.task.flow -->
+
+        <record model="ir.ui.view" id="task_flow_tree">
+            <field name="name">impexp.task.flow.tree</field>
+            <field name="model">impexp.task.flow</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <tree string="Task Flow Form">
+                    <field name="name"/>
+                    <field name="task_ids"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="task_flow_form">
+            <field name="name">impexp.task.flow.form</field>
+            <field name="model">impexp.task.flow</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Task Flow Form" version="7.0">
+                    <sheet>
+                        <h2><field name="name"/></h2>
+                        <field name="task_ids"/>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="task_flow_diagram">
+            <field name="name">impexp.task.flow.diagram</field>
+            <field name="model">impexp.task.flow</field>
+            <field name="type">diagram</field>
+            <field name="arch" type="xml">
+                <diagram string="Task Flow Diagram">
+                    <node object="impexp.task" bgcolor="gray:flow_start==True">
+                        <field name="name"/>
+                        <field name="task"/>
+                        <field name="flow_start" invisible="1"/>
+                    </node>
+                    <arrow object="impexp.task.transition" source="task_from_id" destination="task_to_id">
+                        <field name="task_from_id"/>
+                        <field name="task_to_id"/>
+                    </arrow>
+                </diagram>
+            </field>
+        </record>
+
+        <!-- impexp.task.transition -->
+
+        <record model="ir.ui.view" id="task_transition_form">
+            <field name="name">impexp.task.transition.form</field>
+            <field name="model">impexp.task.transition</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Task Transition Form">
+                    <group>
+                        <field name="task_from_id"/>
+                        <field name="task_to_id"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <!-- menu and window actions -->
+
+        <record model="ir.actions.act_window" id="task_view_action">
+            <field name="name">Tasks</field>
+            <field name="res_model">impexp.task</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="task_tree"/>
+            <field name="target">current</field>
+        </record>
+
+        <record model="ir.actions.act_window" id="task_flow_view_action">
+            <field name="name">Task Flows</field>
+            <field name="res_model">impexp.task.flow</field>
+            <field name="view_mode">tree,diagram,form</field>
+            <field name="view_type">form</field>
+            <field name="target">current</field>
+        </record>
+
+        <menuitem id="menu_impexp_root"
+                  parent="connector.menu_connector_root"
+                  name="Import/Export"
+                  sequence="10"
+                  groups="connector.group_connector_manager"/>
+
+        <menuitem id="menu_impexp_task"
+                  name="Tasks"
+                  parent="menu_impexp_root"
+                  action="task_view_action"/>
+
+        <menuitem id="menu_impexp_task_flow"
+                  name="Task Flows"
+                  parent="menu_impexp_root"
+                  action="task_flow_view_action"/>
+
+    </data>
+</openerp>

--- a/connector_flow/security/ir.model.access.csv
+++ b/connector_flow/security/ir.model.access.csv
@@ -1,0 +1,6 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_impexp_task_flow,Read-only access to impexp.task_flow,model_impexp_task_flow,base.group_user,1,0,0,0
+access_impexp_task,Read-only access to impexp.task,model_impexp_task,base.group_user,1,0,0,0
+access_impexp_task_transition,Read-only access to impexp.task_transition,model_impexp_task_transition,base.group_user,1,0,0,0
+access_impexp_file,Read/write access to impexp.file,model_impexp_file,base.group_user,1,1,1,1
+access_impexp_chunk,Read/write access to impexp.chunk,model_impexp_chunk,base.group_user,1,1,1,1

--- a/connector_flow/task/__init__.py
+++ b/connector_flow/task/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import csv_export
+from . import csv_import
+from . import ftp_upload
+from . import ftp_download

--- a/connector_flow/task/abstract_task.py
+++ b/connector_flow/task/abstract_task.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.addons.connector.session import ConnectorSession
+from openerp.tools.translate import _
+import simplejson
+from base64 import b64encode, b64decode
+
+
+class abstract_task(object):
+
+    def __init__(self, cr, uid, ids):
+        self.session = ConnectorSession(cr, uid)
+        self._id = ids[0]
+
+    def run_task(self, task_id, **kwargs):
+        return self.session.pool.get('impexp.task') \
+            .do_run(self.session.cr, self.session.uid, [task_id], **kwargs)
+
+    def related_action(self, job=None, **kwargs):
+        """Overwrite this method to add a related action function
+           for a specific task type."""
+        pass
+
+    def run(self, **kwargs):
+        """All the task core action happens here"""
+        raise Exception("Not Implemented")
+
+    def run_successor_tasks(self, **kwargs):
+        transition_ids = self.session.search('impexp.task.transition',
+                                             [('task_from_id', '=',
+                                               self._id)])
+        successor_ids = self.session.read('impexp.task.transition',
+                                          transition_ids,
+                                          ['task_to_id'])
+        retval = None
+        for trans in successor_ids:
+            retval = self.run_task(trans['task_to_id'][0], **kwargs)
+        return retval
+
+    def create_file(self, filename, data):
+        ir_attachment_id = self.session.create(
+            'ir.attachment',
+            {'name': filename,
+             'datas': b64encode(data),
+             'datas_fname': filename})
+        file_id = self.session.create(
+            'impexp.file',
+            {'attachment_id': ir_attachment_id,
+             'task_id': self._id,
+             'state': 'done'})
+        return file_id
+
+    def load_file(self, file_id):
+        f = self.session.browse('impexp.file', file_id)
+        if not f.attachment_id.datas:
+            return None
+        return b64decode(f.attachment_id.datas)
+
+
+def action_open_chunk(chunk_id):
+    """Window action to open a view of a given chunk"""
+    return {
+        'name': _("Chunk"),
+        'type': 'ir.actions.act_window',
+        'res_model': 'impexp.chunk',
+        'view_type': 'form',
+        'view_mode': 'form',
+        'res_id': chunk_id,
+    }
+
+
+class abstract_chunk_read_task(abstract_task):
+    """Task that reads (and processes) an existing chunk of data"""
+
+    def run(self, chunk_id=None, **kwargs):
+        chunk = self.session.read('impexp.chunk',
+                                  chunk_id,
+                                  ['data'])['data']
+        kwargs['chunk_data'] = simplejson.loads(chunk)
+        new_state = 'failed'
+        result = None
+        try:
+            result = self.read_chunk(**kwargs)
+            new_state = 'done'
+        except:
+            raise
+        finally:
+            self.session.write('impexp.chunk', chunk_id, {'state': new_state})
+        return result
+
+    def read_chunk(self, **kwargs):
+        pass
+
+    def related_action(self, job=None, **kwargs):
+        """Returns window action to open the chunk belonging to the job.
+           This is an example for a related action function."""
+        chunk_id = job.kwargs.get('chunk_id')
+        if chunk_id:
+            return action_open_chunk(chunk_id)
+
+
+class abstract_chunk_write_task(abstract_task):
+    """Task that writes (and feeds) data as a chunk"""
+    def write_and_run_chunk(self, chunk_data, chunk_name,
+                            async=True, **kwargs):
+        chunk_id = self.session.create('impexp.chunk',
+                                       {'name': chunk_name,
+                                        'data': simplejson.dumps(chunk_data)})
+        return self.run_successor_tasks(chunk_id=chunk_id,
+                                        async=async,
+                                        **kwargs)

--- a/connector_flow/task/csv_export.py
+++ b/connector_flow/task/csv_export.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from .abstract_task import abstract_chunk_read_task
+from cStringIO import StringIO
+
+import csv
+
+
+class csv_export(abstract_chunk_read_task):
+    "Reads a chunk and writes it into a CSV file"
+
+    def read_chunk(self, config=None, chunk_data=None, async=True):
+        if not chunk_data:
+            return
+
+        # output encoding defaults to utf-8
+        encoding = config.get('encoding', 'utf-8')
+
+        def encode_value(value):
+            if isinstance(value, unicode):
+                return value.encode(encoding)
+            return value
+
+        data = StringIO()
+        writer = csv.writer(data)
+        for row in chunk_data:
+            writer.writerow(map(encode_value, row))
+
+        file_id = self.create_file(config.get('filename'), data.getvalue())
+        result = self.run_successor_tasks(file_id=file_id, async=async)
+        if result:
+            return result
+        return file_id
+
+
+class csv_export_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(csv_export_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('csv_export', 'CSV Export')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def csv_export_class(self):
+        return csv_export

--- a/connector_flow/task/csv_import.py
+++ b/connector_flow/task/csv_import.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from .abstract_task import abstract_task
+
+from base64 import b64decode
+import csv
+import simplejson
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class table_row_import(abstract_task):
+    def _row_generator(self, file_data, config=None):
+        """Parses a given blob into rows; returns an iterator to rows.
+           Has to be implemented in derived classes."""
+        raise Exception("Not Implemented")
+
+    def run(self, config=None, file_id=None, async=True, **kwargs):
+        if not file_id:
+            return
+
+        includes_header = config.get('includes_header', False)
+
+        f = self.session.browse('impexp.file', file_id)
+        lineno = 0
+        header = None
+        rows = self._row_generator(b64decode(f.attachment_id.datas),
+                                   config=config)
+        for row in rows:
+            lineno += 1
+            if includes_header and lineno == 1:
+                header = row
+                continue
+            if not row:
+                continue
+            name = '%s, line %d' % (f.attachment_id.datas_fname, lineno)
+            data = row
+            if header:
+                data = dict(zip(header, data))
+            chunk_id = self.session.create('impexp.chunk',
+                                           {'name': name,
+                                            'data': simplejson.dumps(data),
+                                            'file_id': f.id})
+            self.run_successor_tasks(chunk_id=chunk_id, async=async, **kwargs)
+            if lineno % 1000 == 0:
+                _logger.info('Created %d chunks', lineno)
+
+        self.session.write('impexp.file', f.id, {'state': 'done'})
+
+
+class csv_import(table_row_import):
+    """Parses a CSV file and stores the lines as chunks"""
+
+    def _row_generator(self, file_data, config=None):
+        encoding = config.get('encoding', 'utf-8')
+        data = file_data.decode(encoding)\
+                        .encode('utf-8')\
+                        .split("\n")
+        return csv.reader(data)
+
+
+class csv_import_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(csv_import_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('csv_import', 'CSV Import')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def csv_import_class(self):
+        return csv_import

--- a/connector_flow/task/ftp_download.py
+++ b/connector_flow/task/ftp_download.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from .abstract_task import abstract_task
+import ftputil
+import ftputil.session
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class ftp_download(abstract_task):
+    """FTP Configuration options:
+     - host, user, password, port
+     - download_directory:  directory on the FTP server where files are
+                            downloaded from
+     - move_directory:  If present, files will be moved to this directory
+                        on the FTP server after download.
+     - delete_files:  If true, files will be deleted on the FTP server
+                      after download.
+    """
+
+    def _handle_new_source(self, ftp_conn, download_directory, file_name,
+                           move_directory):
+        """open and read given file into create_file method,
+           move file if move_directory is given"""
+        with ftp_conn.open(self._source_name(download_directory, file_name),
+                           "rb") as fileobj:
+            data = fileobj.read()
+        return self.create_file(file_name, data)
+
+    def _source_name(self, download_directory, file_name):
+        """helper to get the full name"""
+        return download_directory + '/' + file_name
+
+    def _move_file(self, ftp_conn, source, target):
+        """Moves a file on the FTP server"""
+        _logger.info('Moving file %s %s' % (source, target))
+        ftp_conn.rename(source, target)
+
+    def _delete_file(self, ftp_conn, source):
+        """Deletes a file from the FTP server"""
+        _logger.info('Deleting file %s' % source)
+        ftp_conn.remove(source)
+
+    def run(self, config=None, async=True):
+        ftp_config = config['ftp']
+        download_directory = ftp_config.get('download_directory', '')
+        move_directory = ftp_config.get('move_directory', '')
+        port_session_factory = ftputil.session.session_factory(
+            port=int(ftp_config.get('port', 21)))
+        with ftputil.FTPHost(ftp_config['host'], ftp_config['user'],
+                             ftp_config['password'],
+                             session_factory=port_session_factory) as ftp_conn:
+
+            file_list = ftp_conn.listdir(download_directory)
+            downloaded_files = []
+            for ftpfile in file_list:
+                if ftp_conn.path.isfile(self._source_name(download_directory,
+                                                          ftpfile)):
+                    file_id = self._handle_new_source(ftp_conn,
+                                                      download_directory,
+                                                      ftpfile,
+                                                      move_directory)
+                    self.run_successor_tasks(file_id=file_id, async=async)
+                    downloaded_files.append(ftpfile)
+
+            # Move/delete files only after all files have been processed.
+            if ftp_config.get('delete_files'):
+                for ftpfile in downloaded_files:
+                    self._delete_file(ftp_conn,
+                                      self._source_name(download_directory,
+                                                        ftpfile))
+            elif move_directory:
+                if not ftp_conn.path.exists(move_directory):
+                    ftp_conn.mkdir(move_directory)
+                for ftpfile in downloaded_files:
+                    self._move_file(
+                        ftp_conn,
+                        self._source_name(download_directory, ftpfile),
+                        self._source_name(move_directory, ftpfile))
+
+
+class ftp_download_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(ftp_download_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('ftp_download', 'FTP Download')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def ftp_download_class(self):
+        return ftp_download

--- a/connector_flow/task/ftp_upload.py
+++ b/connector_flow/task/ftp_upload.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from .abstract_task import abstract_task
+from base64 import b64decode
+import ftputil
+import ftputil.session
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class ftp_upload(abstract_task):
+    """FTP Configuration options:
+     - host, user, password, port
+     - upload_directory:  directory on the FTP server where files are
+                          uploaded to
+    """
+
+    def _handle_existing_target(self, ftp_conn, target_name, filedata):
+        raise Exception("%s already exists" % target_name)
+
+    def _handle_new_target(self, ftp_conn, target_name, filedata):
+        with ftp_conn.open(target_name, mode='wb') as fileobj:
+            fileobj.write(filedata)
+            _logger.info('wrote %s, size %d', target_name, len(filedata))
+
+    def _target_name(self, ftp_conn, upload_directory, filename):
+        return upload_directory + '/' + filename
+
+    def _upload_file(self, config, filename, filedata):
+        ftp_config = config['ftp']
+        upload_directory = ftp_config.get('upload_directory', '')
+        port_session_factory = ftputil.session.session_factory(
+            port=int(ftp_config.get('port', 21))
+            )
+        with ftputil.FTPHost(ftp_config['host'], ftp_config['user'],
+                             ftp_config['password'],
+                             session_factory=port_session_factory) as ftp_conn:
+            target_name = self._target_name(ftp_conn,
+                                            upload_directory,
+                                            filename)
+            if ftp_conn.path.isfile(target_name):
+                self._handle_existing_target(ftp_conn, target_name, filedata)
+            else:
+                self._handle_new_target(ftp_conn, target_name, filedata)
+
+    def run(self, config=None, file_id=None, async=True):
+        f = self.session.pool.get('impexp.file') \
+                .browse(self.session.cr, self.session.uid, file_id)
+        self._upload_file(config, f.attachment_id.datas_fname,
+                          b64decode(f.attachment_id.datas))
+
+
+class ftp_upload_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(ftp_upload_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('ftp_upload', 'FTP Upload')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def ftp_upload_class(self):
+        return ftp_upload

--- a/connector_flow/wizard/__init__.py
+++ b/connector_flow/wizard/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import run_task

--- a/connector_flow/wizard/run_task.py
+++ b/connector_flow/wizard/run_task.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class run_task_wizard(orm.TransientModel):
+    _name = 'impexp.wizard.runtask'
+
+    _columns = {
+        'flow_id': fields.many2one('impexp.task.flow', 'Task Flow'),
+        'task_id': fields.many2one('impexp.task', 'Task', required=True),
+        'datas': fields.binary('File'),
+        'datas_fname': fields.char('File Name', size=256),
+        'async': fields.boolean('Run Asynchronously'),
+        'attachment_id': fields.many2one('ir.attachment', 'Result File'),
+        'state': fields.selection([('input', 'Input'), ('output', 'Output')],
+                                  'State')
+    }
+
+    _defaults = {
+        'state': 'input',
+        'async': True,
+    }
+
+    def onchange_flow(self, cr, uid, ids, flow_id):
+        flow_obj = self.pool.get('impexp.task.flow')
+        flow = flow_obj.browse(cr, uid, flow_id)
+        task_id = False
+        for task in flow.task_ids:
+            if task.flow_start:
+                task_id = task.id
+        return {'value': {'task_id': task_id}}
+
+    def run_task(self, cr, uid, ids, context=None):
+        run_task = self.browse(cr, uid, ids)[0]
+        kwargs = {'async': run_task.async}
+        file_obj = self.pool.get('impexp.file')
+        if run_task.datas:
+            upload_name = "Upload from run task wizard: %s" \
+                % run_task.datas_fname
+            ir_attachment_id = self.pool.get('ir.attachment')\
+                .create(cr, uid,
+                        {'name': upload_name,
+                         'datas': run_task.datas,
+                         'datas_fname': run_task.datas_fname})
+            file_id = file_obj\
+                .create(cr, uid,
+                        {'attachment_id': ir_attachment_id,
+                         'task_id': run_task.task_id.id})
+            kwargs['file_id'] = file_id
+        result_id = self.pool.get('impexp.task')\
+            .do_run(cr, uid, [run_task.task_id.id], **kwargs)
+        if result_id:
+            res = file_obj.read(cr, uid, result_id, ['attachment_id'])
+            attachment_id = res['attachment_id'][0]
+            self.write(cr, uid, ids,
+                       {'attachment_id': attachment_id, 'state': 'output'})
+            return {
+                'type': 'ir.actions.act_window',
+                'res_model': self._name,
+                'view_mode': 'form',
+                'view_type': 'form',
+                'res_id': ids[0],
+                'views': [(False, 'form')],
+                'target': 'new',
+            }

--- a/connector_flow/wizard/run_task_view.xml
+++ b/connector_flow/wizard/run_task_view.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record model="ir.ui.view" id="run_task_form">
+            <field name="name">impexp.wizard.runtask.form</field>
+            <field name="model">impexp.wizard.runtask</field>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                <form string="Task Form" version="7.0">
+                    <field name="state" invisible="1"/>
+                    <group states="input">
+                        <field name="flow_id" on_change="onchange_flow(flow_id)"/>
+                        <field name="task_id"/>
+                        <field name="datas" filename="datas_fname" />
+                        <field name="datas_fname" invisible="1"/>
+                        <field name="async"/>
+                    </group>
+                    <div states="output">
+                        The task returned <field name="attachment_id" readonly="1" />
+                    </div>
+                    <footer states="input">
+                        <button name="run_task" string="Run Task" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel"/>
+                    </footer>
+                    <footer states="output">
+                        <button special="cancel" string="Close" type="object"/>
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.actions.act_window" id="run_task_view_action">
+            <field name="name">Run Task</field>
+            <field name="res_model">impexp.wizard.runtask</field>
+            <field name="view_mode">form</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="task_tree"/>
+            <field name="target">new</field>
+        </record>
+
+        <menuitem id="menu_impexp_run_task"
+                  name="Run Task"
+                  parent="menu_impexp_root"
+                  action="run_task_view_action"/>
+
+    </data>
+</openerp>

--- a/connector_flow_example_ftp/__init__.py
+++ b/connector_flow_example_ftp/__init__.py
@@ -1,0 +1,2 @@
+from . import improved_ftp
+from . import res_partner

--- a/connector_flow_example_ftp/__openerp__.py
+++ b/connector_flow_example_ftp/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Example (Partner Export via FTP) for connector_flow',
+    'version': '0.1',
+    'description': """This module provides a demo task flow for the
+*connector_flow* module. It implements a very simple export and
+upload of all res.partner to an FTP server in a two-column CSV file
+(name,zip code).""",
+    'category': 'Connector',
+    'license': 'AGPL-3',
+    'author': 'initOS GmbH & Co. KG',
+    'website': 'http://www.initos.com',
+    'depends': [
+        'connector_flow',
+    ],
+    'data': [
+    ],
+    'demo': [
+        'demo/task_demo.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/connector_flow_example_ftp/demo/task_demo.xml
+++ b/connector_flow_example_ftp/demo/task_demo.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <!-- Task flow -->
+
+        <record model="impexp.task.flow" id="task_partner_to_ftp_flow">
+            <field name="name">res.partner to FTP</field>
+        </record>
+
+        <!-- partner to FTP task and task transition -->
+
+        <record model="impexp.task" id="task_partner_to_ftp_1">
+            <field name="name">res.partner to FTP, part 1 (data to chunk)</field>
+            <field name="task">csv_partner_export</field>
+            <field name="flow_id" ref="task_partner_to_ftp_flow"/>
+            <field name="flow_start" eval="True"/>
+        </record>
+
+        <record model="impexp.task" id="task_partner_to_ftp_2">
+            <field name="name">res.partner to FTP, part 2 (chunk to CSV)</field>
+            <field name="task">csv_export</field>
+            <field name="flow_id" ref="task_partner_to_ftp_flow"/>
+            <field name="config"><![CDATA[{'filename': 'res.partner.csv'}]]></field>
+        </record>
+
+        <record model="impexp.task" id="task_partner_to_ftp_3">
+            <field name="name">res.partner to FTP, part 3 (CSV to FTP)</field>
+            <field name="task">ftp_upload</field>
+            <field name="flow_id" ref="task_partner_to_ftp_flow"/>
+            <field name="config"><![CDATA[{'ftp': {
+'upload_directory': '/home/dummy_user',
+'host': '127.0.0.1',
+'user': 'dummy_user',
+'password': 'dummy_password'
+}}]]></field>
+        </record>
+
+        <record model="impexp.task.transition" id="task_transition_partner_to_ftp_1">
+            <field name="task_from_id" ref="task_partner_to_ftp_1"/>
+            <field name="task_to_id" ref="task_partner_to_ftp_2"/>
+        </record>
+
+        <record model="impexp.task.transition" id="task_transition_partner_to_ftp_2">
+            <field name="task_from_id" ref="task_partner_to_ftp_2"/>
+            <field name="task_to_id" ref="task_partner_to_ftp_3"/>
+        </record>
+    </data>
+</openerp>

--- a/connector_flow_example_ftp/improved_ftp.py
+++ b/connector_flow_example_ftp/improved_ftp.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.addons.connector_flow.task.ftp_upload import ftp_upload
+import time
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class improved_ftp_upload(ftp_upload):
+    def _handle_existing_target(self, ftp_conn, target_name, filedata):
+        _logger.info('Skip existing target %s' % target_name)
+
+    def _target_name(self, ftp_conn, upload_directory, filename):
+        return "%s/%f_%s" % (upload_directory,
+                             time.time(),
+                             filename)
+
+
+class improved_ftp_upload_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(improved_ftp_upload_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('improved_ftp_upload', 'Improved FTP Upload')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def improved_ftp_upload_class(self):
+        return improved_ftp_upload

--- a/connector_flow_example_ftp/res_partner.py
+++ b/connector_flow_example_ftp/res_partner.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.addons.connector_flow.task.abstract_task \
+    import abstract_chunk_write_task
+
+
+class csv_partner_export(abstract_chunk_write_task):
+    def run(self, config=None, async=True):
+        # We will store the data that we want to export
+        #  as list of lists, corresponding to the structured rows
+        #  in the export file
+        result_list = [['Name', 'ZIP Code']]
+        partner_obj = self.session.pool.get('res.partner')
+        partner_ids = partner_obj.search(self.session.cr, self.session.uid, [])
+        for p in partner_obj.browse(self.session.cr, self.session.uid,
+                                    partner_ids):
+            result_list.append([p.name, p.zip])
+
+        return self.write_and_run_chunk(result_list, 'List of all res.partner',
+                                        async=async)
+
+
+class csv_partner_export_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(csv_partner_export_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('csv_partner_export', 'CSV Partner Export')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def csv_partner_export_class(self):
+        return csv_partner_export

--- a/connector_flow_example_product/__init__.py
+++ b/connector_flow_example_product/__init__.py
@@ -1,0 +1,1 @@
+from . import product

--- a/connector_flow_example_product/__openerp__.py
+++ b/connector_flow_example_product/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Example (Product Catalog Import) for connector_flow',
+    'version': '0.1',
+    'description': """This module provides a demo task flow for the
+*connector_flow* module. It implements a very simple product catalog import
+from CSV""",
+    'category': 'Connector',
+    'license': 'AGPL-3',
+    'author': 'initOS GmbH & Co. KG',
+    'website': 'http://www.initos.com',
+    'depends': [
+        'connector_flow',
+        'sale',
+    ],
+    'data': [
+    ],
+    'demo': [
+        'demo/task_demo.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/connector_flow_example_product/contrib/fruit_catalog.csv
+++ b/connector_flow_example_product/contrib/fruit_catalog.csv
@@ -1,0 +1,5 @@
+Name,Preis EK,Preis VK,Image URL
+Apfel,1,1.2,http://upload.wikimedia.org/wikipedia/commons/1/15/Red_Apple.jpg
+Kiwi,0.5,0.7,http://upload.wikimedia.org/wikipedia/commons/6/6d/Kiwi_%28Actinidia_chinensis%29_2_Luc_Viatour.jpg
+Limette,0.3,0.6,http://upload.wikimedia.org/wikipedia/commons/e/ef/Citrus_lime.png
+Orange,1.2,1.5,http://www.initos.com/this-url-is-not-valid

--- a/connector_flow_example_product/demo/task_demo.xml
+++ b/connector_flow_example_product/demo/task_demo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <!-- Task flow -->
+
+        <record model="impexp.task.flow" id="task_flow_product_catalog_import">
+            <field name="name">Product Catalog Import</field>
+        </record>
+
+        <!-- Task and task transition -->
+
+        <record model="impexp.task" id="task_product_catalog_import_1">
+            <field name="name">Product catalog CSV to chunks</field>
+            <field name="task">csv_import</field>
+            <field name="flow_id" ref="task_flow_product_catalog_import"/>
+            <field name="flow_start" eval="True"/>
+            <field name="config"><![CDATA[{'includes_header': True}]]></field>
+        </record>
+
+        <record model="impexp.task" id="task_product_catalog_import_2">
+            <field name="name">Product catalog chunks to products</field>
+            <field name="task">product_catalog_import</field>
+            <field name="flow_id" ref="task_flow_product_catalog_import"/>
+        </record>
+
+        <record model="impexp.task.transition" id="task_product_catalog_import_1">
+            <field name="task_from_id" ref="task_product_catalog_import_1"/>
+            <field name="task_to_id" ref="task_product_catalog_import_2"/>
+        </record>
+    </data>
+</openerp>

--- a/connector_flow_example_product/demo/task_demo.xml
+++ b/connector_flow_example_product/demo/task_demo.xml
@@ -23,7 +23,7 @@
             <field name="flow_id" ref="task_flow_product_catalog_import"/>
         </record>
 
-        <record model="impexp.task.transition" id="task_product_catalog_import_1">
+        <record model="impexp.task.transition" id="task_transition_product_catalog_import_1">
             <field name="task_from_id" ref="task_product_catalog_import_1"/>
             <field name="task_to_id" ref="task_product_catalog_import_2"/>
         </record>

--- a/connector_flow_example_product/product.py
+++ b/connector_flow_example_product/product.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.addons.connector_flow.task.abstract_task \
+    import abstract_chunk_read_task
+import urllib2
+from base64 import b64encode
+
+
+class product_catalog_import(abstract_chunk_read_task):
+    def read_chunk(self, config=None, chunk_data=None, async=True):
+        product_data = {
+            'name': chunk_data.get('Name'),
+            'list_price': float(chunk_data.get('Preis VK')),
+            'standard_price': float(chunk_data.get('Preis EK')),
+        }
+        product_image_url = chunk_data.get('Image URL')
+        if product_image_url:
+            url_obj = urllib2.urlopen(product_image_url)
+            product_data['image'] = b64encode(url_obj.read())
+        self.session.create('product.product', product_data)
+
+
+class product_catalog_import_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(product_catalog_import_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('product_catalog_import', 'Produkt Catalog Import')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def product_catalog_import_class(self):
+        return product_catalog_import

--- a/connector_flow_xls/__init__.py
+++ b/connector_flow_xls/__init__.py
@@ -1,0 +1,1 @@
+from . import task

--- a/connector_flow_xls/__openerp__.py
+++ b/connector_flow_xls/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'XLS Import for connector_flow',
+    'version': '0.1',
+    'description': """This module provides an XLS import task for the
+ connector_flow module""",
+    'category': 'Connector',
+    'author': 'initOS GmbH & Co. KG',
+    'license': 'AGPL-3',
+    'website': 'http://www.initos.com',
+    'depends': [
+        'connector_flow',
+    ],
+    'external_dependencies': {
+        'python': ['xlrd'],
+    },
+    'data': [
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/connector_flow_xls/task/__init__.py
+++ b/connector_flow_xls/task/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import xls_import

--- a/connector_flow_xls/task/xls_import.py
+++ b/connector_flow_xls/task/xls_import.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+from openerp.addons.connector_flow.task.csv_import import table_row_import
+
+from xlrd import open_workbook
+import logging
+_logger = logging.getLogger(__name__)
+
+
+class xls_import(table_row_import):
+    """Parses an XLS file and stores the lines as chunks"""
+
+    def _row_generator(self, file_data, config=None):
+        wb = open_workbook(file_contents=file_data)
+        # use only first sheet
+        sheet = wb.sheet_by_index(0)
+        for row in range(sheet.nrows):
+            yield [sheet.cell(row, col).value for col in range(sheet.ncols)]
+
+
+class xls_import_task(orm.Model):
+    _inherit = 'impexp.task'
+
+    def _get_available_tasks(self, cr, uid, context=None):
+        return super(xls_import_task, self) \
+            ._get_available_tasks(cr, uid, context=context) \
+            + [('xls_import', 'XLS Import')]
+
+    _columns = {
+        'task': fields.selection(_get_available_tasks, string='Task',
+                                 required=True),
+    }
+
+    def xls_import_class(self):
+        return xls_import

--- a/fix_bug_1316948/__init__.py
+++ b/fix_bug_1316948/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_ui_view

--- a/fix_bug_1316948/__openerp__.py
+++ b/fix_bug_1316948/__openerp__.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Bugfix module for 1316948 on launchpad',
+    'version': '0.1',
+    'description': """This module attempts to fix
+https://bugs.launchpad.net/openobject-server/+bug/1316948""",
+    'category': '',
+    'license': 'AGPL-3',
+    'author': 'OpenERP, initOS GmbH & Co. KG',
+    'website': 'http://www.initos.com',
+    'depends': [
+        'base',
+    ],
+    'data': [
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/fix_bug_1316948/ir_ui_view.py
+++ b/fix_bug_1316948/ir_ui_view.py
@@ -1,0 +1,71 @@
+from openerp.osv import orm
+from openerp import tools
+from openerp.tools import graph
+
+class view(orm.Model):
+    _inherit = 'ir.ui.view'
+
+    def graph_get(self, cr, uid, id, model, node_obj, conn_obj, src_node, des_node, label, scale, context=None):
+        nodes=[]
+        nodes_name=[]
+        transitions=[]
+        start=[]
+        tres={}
+        labels={}
+        no_ancester=[]
+        blank_nodes = []
+
+        _Model_Obj=self.pool.get(model)
+        _Node_Obj=self.pool.get(node_obj)
+        _Arrow_Obj=self.pool.get(conn_obj)
+
+        for model_key,model_value in _Model_Obj._columns.items():
+                if model_value._type=='one2many':
+                    if model_value._obj==node_obj:
+                        _Node_Field=model_key
+                        _Model_Field=model_value._fields_id
+                    for node_key,node_value in _Node_Obj._columns.items():
+                        if node_value._type=='one2many':
+                             if node_value._obj==conn_obj:
+                                 if des_node in _Arrow_Obj._columns and node_value._fields_id == des_node:
+                                    _Source_Field=node_key
+                                 if src_node in _Arrow_Obj._columns and node_value._fields_id == src_node:
+                                    _Destination_Field=node_key
+
+        datas = _Model_Obj.read(cr, uid, id, [],context)
+        for a in _Node_Obj.read(cr,uid,datas[_Node_Field],[]):
+            if a[_Source_Field] or a[_Destination_Field]:
+                nodes_name.append((a['id'],a['name']))
+                nodes.append(a['id'])
+            else:
+                blank_nodes.append({'id': a['id'],'name':a['name']})
+
+            if a.has_key('flow_start') and a['flow_start']:
+                start.append(a['id'])
+            else:
+                if not a[_Source_Field]:
+                    no_ancester.append(a['id'])
+            for t in _Arrow_Obj.read(cr,uid, a[_Destination_Field],[]):
+                transitions.append((a['id'], t[des_node][0]))
+                tres[str(t['id'])] = (a['id'],t[des_node][0])
+                label_string = ""
+                if label:
+                    for lbl in eval(label):
+                        if t.has_key(tools.ustr(lbl)) and tools.ustr(t[lbl])=='False':
+                            label_string += ' '
+                        else:
+                            label_string = label_string + " " + tools.ustr(t[lbl])
+                labels[str(t['id'])] = (a['id'],label_string)
+        g  = graph(nodes, transitions, no_ancester)
+        g.process(start)
+        g.scale(*scale)
+        result = g.result_get()
+        results = {}
+        for node in nodes_name:
+            results[str(node[0])] = result[node[0]]
+            results[str(node[0])]['name'] = node[1]
+        return {'nodes': results,
+                'transitions': tres,
+                'label' : labels,
+                'blank_nodes': blank_nodes,
+                'node_parent_field': _Model_Field,}


### PR DESCRIPTION
Some time ago we at initOS announced that we worked on a framework on top of the connector to implement import/export tasks. Since then the code has matured and has proven useful in customer projects, so we want to share the result.

connector_flow is inspired by existing file_exchange and connector_file addons, but aims to be as lightweight and flexible as possible. The idea is to have independent tasks that are organized in a flow similar to workflows. Along with the module we provide two simple examples that use connector_flow for exporting partners as CSV via FTP and for importing product data from CSV, respectively.
