### PR TITLE
[IMP] connector_importer: new option 'use_job' on import type

### DIFF
--- a/connector_importer/models/import_type.py
+++ b/connector_importer/models/import_type.py
@@ -46,6 +46,16 @@ class ImportType(models.Model):
             product.supplierinfo::supplierinfo.importer.component.name
         """
     )
+    use_job = fields.Boolean(
+        string="Use job",
+        help=(
+            "For each importer used in the settings, one job will be spawned. "
+            "Untick the box if an importer depends on the result of a "
+            "previous one (for instance to link a record to the previously "
+            "created one)."
+        ),
+        default=True,
+    )
     _sql_constraints = [
         ('key_uniq', 'unique (key)', _("Import type `key` must be unique!"))
     ]

--- a/connector_importer/models/record.py
+++ b/connector_importer/models/record.py
@@ -112,9 +112,11 @@ class ImportRecord(models.Model, JobRelatedMixin):
     def run_import(self):
         """ queue a job for importing data stored in to self
         """
+        use_job = self.recordset_id.import_type_id.use_job
         job_method = self.with_delay().import_record
         if self.debug_mode():
             logger.warn('### DEBUG MODE ACTIVE: WILL NOT USE QUEUE ###')
+        if self.debug_mode() or not use_job:
             job_method = self.import_record
         _result = {}
         for item in self:
@@ -127,7 +129,7 @@ class ImportRecord(models.Model, JobRelatedMixin):
                 result = job_method(
                     importer, model, is_last_importer=is_last_importer)
                 _result[model] = result
-                if self.debug_mode():
+                if self.debug_mode() or not use_job:
                     # debug mode, no job here: reset it!
                     item.write({'job_id': False})
                 else:


### PR DESCRIPTION
By default one job is spawned for each data model/importer used in a
import type. It works well if the records to import have no relation
between them, but if we choose to disable this behavior we are able to
link records imported from one importer to another as we are in the same
SQL transaction (e.g. an order and its lines).