### PR TITLE
FIX reporter.mixin description

### DIFF
--- a/connector_importer/models/reporter.py
+++ b/connector_importer/models/reporter.py
@@ -20,6 +20,7 @@ class ReporterMixin(models.AbstractModel):
     See the CSV example for a real case.
     """
     _name = 'reporter.mixin'
+    _description = "Mixin used to produce import summary"
 
     report_extension = '.txt'
 


### PR DESCRIPTION
It fix
`WARNING db odoo.models: The model reporter.mixin has no _description`
please could you have a look @sebalix @simahawk 
