### PR TITLE
[IMP] connector_importer: handle the unique key as an external/XML ID

### DIFF
--- a/connector_importer/__manifest__.py
+++ b/connector_importer/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Connector Importer',
     'summary': """This module takes care of import sessions.""",
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'depends': [
         'connector',
         'queue_job',

--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -66,7 +66,9 @@ class RecordImporter(Component):
     _record_handler_usage = 'odoorecord.handler'
     _tracking_handler_usage = 'tracking.handler'
     # a unique key (field name) to retrieve the odoo record
+    # if this key is an external/XML ID, set 'odoo_unique_key_is_xmlid' to True
     odoo_unique_key = ''
+    odoo_unique_key_is_xmlid = False
 
     def _init_importer(self, recordset):
         self.recordset = recordset
@@ -74,7 +76,8 @@ class RecordImporter(Component):
         self.record_handler = self.component(usage=self._record_handler_usage)
         self.record_handler._init_handler(
             importer=self,
-            unique_key=self.odoo_unique_key
+            unique_key=self.odoo_unique_key,
+            unique_key_is_xmlid=self.odoo_unique_key_is_xmlid
         )
         # tracking handler is responsible for logging and chunk reports
         self.tracker = self.component(usage=self._tracking_handler_usage)
@@ -168,7 +171,8 @@ class RecordImporter(Component):
             }
         missing = (not dest_key.startswith('__') and
                    values.get(dest_key) is None)
-        if missing:
+        is_xmlid = (dest_key == unique_key and self.odoo_unique_key_is_xmlid)
+        if missing and not is_xmlid:
             msg = 'MISSING REQUIRED DESTINATION KEY={}'.format(dest_key)
             if unique_key and values.get(unique_key):
                 msg += ': {}={}'.format(

--- a/connector_importer/components/odoorecord.py
+++ b/connector_importer/components/odoorecord.py
@@ -13,6 +13,7 @@ class OdooRecordHandler(Component):
     _usage = 'odoorecord.handler'
 
     unique_key = ''
+    unique_key_is_xmlid = False
     importer = None
     # By default odoo ignores create_uid/write_uid in vals.
     # If you enable this flags and `create_uid` and/or `write_uid`
@@ -22,9 +23,11 @@ class OdooRecordHandler(Component):
     override_create_date = False
     override_write_uid = False
 
-    def _init_handler(self, importer=None, unique_key=None):
+    def _init_handler(
+            self, importer=None, unique_key=None, unique_key_is_xmlid=False):
         self.importer = importer
         self.unique_key = unique_key
+        self.unique_key_is_xmlid = unique_key_is_xmlid
 
     def odoo_find_domain(self, values, orig_values):
         """Domain to find the record in odoo."""
@@ -34,6 +37,11 @@ class OdooRecordHandler(Component):
         """Find any existing item in odoo."""
         if not self.unique_key:
             return self.model
+        if self.unique_key_is_xmlid:
+            item = self.env.ref(
+                values[self.unique_key], raise_if_not_found=False
+            )
+            return item
         item = self.model.search(
             self.odoo_find_domain(values, orig_values),
             order='create_date desc', limit=1)
@@ -81,6 +89,20 @@ class OdooRecordHandler(Component):
         self.odoo_post_create(odoo_record, values, orig_values)
         translatable = self.importer.collect_translatable(values, orig_values)
         self.update_translations(odoo_record, translatable)
+        # Set the external ID if necessary
+        if self.unique_key_is_xmlid:
+            external_id = values[self.unique_key]
+            if not self.env.ref(external_id, raise_if_not_found=False):
+                module, id_ = external_id.split(".", 1)
+                self.env['ir.model.data'].create(
+                    {
+                        'name': id_,
+                        'module': module,
+                        'model': odoo_record._name,
+                        'res_id': odoo_record.id,
+                        'noupdate': False,
+                    }
+                )
         return odoo_record
 
     def odoo_pre_write(self, odoo_record, values, orig_values):

--- a/connector_importer/readme/ROADMAP.rst
+++ b/connector_importer/readme/ROADMAP.rst
@@ -4,3 +4,5 @@
   The job is automatically retried a second time (without concurrency errors).
   For small files it's not a big issue, but for files with a huge amount of
   lines it takes time to process them two times.
+* unit tests from `tests.test_source_csv` are not imported (Odoo ignores them)
+  and they need to be fixed

--- a/connector_importer/tests/__init__.py
+++ b/connector_importer/tests/__init__.py
@@ -2,4 +2,7 @@ from . import test_backend
 from . import test_cron
 from . import test_import_type
 from . import test_recordset
+from . import test_record_importer
+from . import test_record_importer_basic
+from . import test_record_importer_xmlid
 from . import test_source

--- a/connector_importer/tests/fake_components.py
+++ b/connector_importer/tests/fake_components.py
@@ -36,3 +36,44 @@ class PartnerRecordImporter(Component):
         return {'tracking_disable': True}
 
     write_context = create_context
+
+
+# Same component but with the "id" source column handled as an XML-ID
+
+class PartnerMapperXMLID(Component):
+    _name = 'fake.partner.mapper.xmlid'
+    _inherit = 'importer.base.mapper'
+    _apply_on = 'res.partner'
+
+    required = {
+        'fullname': 'name',
+    }
+
+    defaults = [
+        ('is_company', False),
+    ]
+
+    direct = [
+        ('id', 'id'),
+        ('id', 'ref'),
+        ('fullname', 'name'),
+    ]
+
+
+class PartnerRecordImporterXMLID(Component):
+    _name = 'fake.partner.importer.xmlid'
+    _inherit = 'importer.record'
+    _apply_on = 'res.partner'
+
+    odoo_unique_key = 'id'
+    odoo_unique_key_is_xmlid = True
+
+    def create_context(self):
+        return {'tracking_disable': True}
+
+    def prepare_line(self, line):
+        res = super().prepare_line(line)
+        res["id"] = "__import__." + line["id"]
+        return res
+
+    write_context = create_context

--- a/connector_importer/tests/test_record_importer_xmlid.py
+++ b/connector_importer/tests/test_record_importer_xmlid.py
@@ -1,0 +1,58 @@
+# Author: Simone Orsi
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tools import mute_logger
+
+from .fake_components import PartnerMapperXMLID, PartnerRecordImporterXMLID
+from .test_recordset_importer import TestImporterBase
+
+# TODO: really annoying when running tests. Remove or find a better way
+logging.getLogger('PIL.PngImagePlugin').setLevel(logging.ERROR)
+logging.getLogger('passlib.registry').setLevel(logging.ERROR)
+
+
+class TestRecordImporterXMLID(TestImporterBase):
+
+    def _setup_records(self):
+        super()._setup_records()
+        self.recordset.import_type_id.settings = (
+            'res.partner::fake.partner.importer.xmlid')
+        # The components registry will be handled by the
+        # `import.record.import_record()' method when initializing its
+        # WorkContext
+        self.record = self.env['import.record'].with_context(
+            test_components_registry=self.comp_registry).create(
+                {'recordset_id': self.recordset.id})
+        # no jobs thanks (I know, we should test this too at some point :))
+        self.backend.debug_mode = True
+
+    def _get_components(self):
+        return [PartnerMapperXMLID, PartnerRecordImporterXMLID]
+
+    @mute_logger('[importer]')
+    def test_importer_create(self):
+        # generate 10 records
+        count = 10
+        lines = self._fake_lines(count, keys=('id', 'fullname'))
+        # set them on record
+        self.record.set_data(lines)
+        res = self.record.run_import()
+        # in any case we'll get this per each model if the import is not broken
+        self.assertEqual(res, {'res.partner': 'ok'})
+        report = self.recordset.get_report()
+        self.assertEqual(len(report['res.partner']['created']), 10)
+        self.assertEqual(len(report['res.partner']['errored']), 0)
+        self.assertEqual(len(report['res.partner']['updated']), 0)
+        self.assertEqual(len(report['res.partner']['skipped']), 0)
+        self.assertEqual(
+            self.env['res.partner'].search_count([('ref', 'like', 'id_%')]),
+            10
+        )
+        # Check XML-IDs
+        for i in range(1, count + 1):
+            partner = self.env.ref(
+                "__import__.id_{}".format(i), raise_if_not_found=False)
+            self.assertTrue(partner)

--- a/connector_importer/tests/test_recordset_importer.py
+++ b/connector_importer/tests/test_recordset_importer.py
@@ -44,7 +44,10 @@ class TestImporterBase(common.TransactionComponentRegistryCase):
         super().setUp()
         self._setup_records()
         self._load_module_components('connector_importer')
-        self._build_components(PartnerMapper, PartnerRecordImporter)
+        self._build_components(*self._get_components())
+
+    def _get_components(self):
+        return [PartnerMapper, PartnerRecordImporter]
 
     def _setup_records(self):
         self.backend = self.env['import.backend'].create({


### PR DESCRIPTION
'importer.record' and 'importer.odoorecord.handler' components have been
updated to handle the 'odoo_unique_key' attribute as an XML-ID if the
new attribute 'odoo_unique_key_is_xmlid' is set to 'True'.
This XML-ID will then be used as usual to find an existing record, and
will be set on the created record if it doesn't already exist.

ping @simahawk 