### PR TITLE
[FIX] connector_importer: fix 'source_ref_id' field

### DIFF
--- a/connector_importer/models/sources/source_mixin.py
+++ b/connector_importer/models/sources/source_mixin.py
@@ -27,7 +27,10 @@ class ImportSourceConsumerMixin(models.AbstractModel):
         string="Source",
         compute="_compute_source_ref_id",
         selection="_selection_source_ref_id",
-        store=True,
+        # NOTE: do not store a computed fields.Reference, Odoo crashes
+        # with an error message "Mixing appels and orange..." when performing
+        # a self.recompute() on such fields.
+        store=False,
     )
     source_config_summary = fields.Html(
         compute="_compute_source_config_summary", readonly=True


### PR DESCRIPTION
Don't store it to not crash Odoo with a message like:

```
odoo.tools.convert.ParseError: "Mixing apples and oranges: import.source.csv(40,).union(import.source.csv.sftp(3,))" while parsing /odoo/local-src/customer_importer/views/source_csv_sftp.xml:4, near
<odoo>
```

This issue occurs only on Odoo 13.0.
ping @simahawk 