### PR TITLE
[13.0][IMP] connector_importer: handle the unique key as an external/XML ID

### DIFF
--- a/connector_importer/__manifest__.py
+++ b/connector_importer/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Connector Importer",
     "summary": """This module takes care of import sessions.""",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.1.0",
     "depends": ["connector", "queue_job"],
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/connector_importer/readme/ROADMAP.rst
+++ b/connector_importer/readme/ROADMAP.rst
@@ -9,3 +9,5 @@
 * trigger an event at the end of the whole import (to be able to hook custom
   behavior like move imported files on a remote filesystem).
 * move generic functions from `utils.mapper_utils` to the `connector` module
+* unit tests from `tests.test_source_csv` are not imported (Odoo ignores them)
+  and they need to be fixed

--- a/connector_importer/tests/__init__.py
+++ b/connector_importer/tests/__init__.py
@@ -2,4 +2,7 @@ from . import test_backend
 from . import test_cron
 from . import test_import_type
 from . import test_recordset
+from . import test_record_importer
+from . import test_record_importer_basic
+from . import test_record_importer_xmlid
 from . import test_source

--- a/connector_importer/tests/fake_components.py
+++ b/connector_importer/tests/fake_components.py
@@ -28,3 +28,37 @@ class PartnerRecordImporter(Component):
         return {"tracking_disable": True}
 
     write_context = create_context
+
+
+# Same component but with the "id" source column handled as an XML-ID
+
+
+class PartnerMapperXMLID(Component):
+    _name = "fake.partner.mapper.xmlid"
+    _inherit = "importer.base.mapper"
+    _apply_on = "res.partner"
+
+    required = {"fullname": "name"}
+
+    defaults = [("is_company", False)]
+
+    direct = [("id", "id"), ("id", "ref"), ("fullname", "name")]
+
+
+class PartnerRecordImporterXMLID(Component):
+    _name = "fake.partner.importer.xmlid"
+    _inherit = "importer.record"
+    _apply_on = "res.partner"
+
+    odoo_unique_key = "id"
+    odoo_unique_key_is_xmlid = True
+
+    def create_context(self):
+        return {"tracking_disable": True}
+
+    def prepare_line(self, line):
+        res = super().prepare_line(line)
+        res["id"] = "__import__." + line["id"]
+        return res
+
+    write_context = create_context

--- a/connector_importer/tests/test_record_importer_xmlid.py
+++ b/connector_importer/tests/test_record_importer_xmlid.py
@@ -1,0 +1,60 @@
+# Author: Simone Orsi
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tools import mute_logger
+
+from .fake_components import PartnerMapperXMLID, PartnerRecordImporterXMLID
+from .test_recordset_importer import TestImporterBase
+
+# TODO: really annoying when running tests. Remove or find a better way
+logging.getLogger("PIL.PngImagePlugin").setLevel(logging.ERROR)
+logging.getLogger("passlib.registry").setLevel(logging.ERROR)
+
+
+class TestRecordImporterXMLID(TestImporterBase):
+    def _setup_records(self):
+        super()._setup_records()
+        self.recordset.import_type_id.settings = (
+            "res.partner::fake.partner.importer.xmlid"
+        )
+        # The components registry will be handled by the
+        # `import.record.import_record()' method when initializing its
+        # WorkContext
+        self.record = (
+            self.env["import.record"]
+            .with_context(test_components_registry=self.comp_registry)
+            .create({"recordset_id": self.recordset.id})
+        )
+        # no jobs thanks (I know, we should test this too at some point :))
+        self.backend.debug_mode = True
+
+    def _get_components(self):
+        return [PartnerMapperXMLID, PartnerRecordImporterXMLID]
+
+    @mute_logger("[importer]")
+    def test_importer_create(self):
+        # generate 10 records
+        count = 10
+        lines = self._fake_lines(count, keys=("id", "fullname"))
+        # set them on record
+        self.record.set_data(lines)
+        res = self.record.run_import()
+        # in any case we'll get this per each model if the import is not broken
+        self.assertEqual(res, {"res.partner": "ok"})
+        report = self.recordset.get_report()
+        self.assertEqual(len(report["res.partner"]["created"]), 10)
+        self.assertEqual(len(report["res.partner"]["errored"]), 0)
+        self.assertEqual(len(report["res.partner"]["updated"]), 0)
+        self.assertEqual(len(report["res.partner"]["skipped"]), 0)
+        self.assertEqual(
+            self.env["res.partner"].search_count([("ref", "like", "id_%")]), 10
+        )
+        # Check XML-IDs
+        for i in range(1, count + 1):
+            partner = self.env.ref(
+                "__import__.id_{}".format(i), raise_if_not_found=False
+            )
+            self.assertTrue(partner)

--- a/connector_importer/tests/test_recordset_importer.py
+++ b/connector_importer/tests/test_recordset_importer.py
@@ -45,7 +45,10 @@ class TestImporterBase(common.TransactionComponentRegistryCase):
         super().setUp()
         self._setup_records()
         self._load_module_components("connector_importer")
-        self._build_components(PartnerMapper, PartnerRecordImporter)
+        self._build_components(*self._get_components())
+
+    def _get_components(self):
+        return [PartnerMapper, PartnerRecordImporter]
 
     def _setup_records(self):
         self.backend = self.env["import.backend"].create(


### PR DESCRIPTION
Forward port of https://github.com/OCA/connector-interfaces/pull/56 (12.0).

'importer.record' and 'importer.odoorecord.handler' components have been
updated to handle the 'odoo_unique_key' attribute as an XML-ID if the
new attribute 'odoo_unique_key_is_xmlid' is set to 'True'.
This XML-ID will then be used as usual to find an existing record, and
will be set on the created record if it doesn't already exist.

ping @simahawk @guewen 