### PR TITLE
[FIX] connector_importer: guess the CSV encoding when generating the report

### DIFF
--- a/connector_importer/__manifest__.py
+++ b/connector_importer/__manifest__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Connector Importer',
     'summary': """This module takes care of import sessions.""",
-    'version': '12.0.1.3.1',
+    'version': '12.0.1.3.2',
     'depends': [
         'connector',
         'queue_job',

--- a/connector_importer/models/reporter.py
+++ b/connector_importer/models/reporter.py
@@ -3,11 +3,14 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import models, api
 import csv
 import io
 import time
 import base64
+
+from odoo import models, api
+
+from ..utils.import_utils import get_encoding
 
 
 class ReporterMixin(models.AbstractModel):
@@ -137,7 +140,10 @@ class CSVReporter(models.AbstractModel):
                     extra_keys.append(self._report_make_key(key, model=model))
 
         source = recordset.get_source()
-        orig_content = base64.b64decode(source.csv_file).decode().splitlines()
+        csv_file_bin = base64.b64decode(source.csv_file)
+        # Try to guess the encoding of the file supplied
+        csv_file_encoding = get_encoding(csv_file_bin).get("encoding", "utf-8")
+        orig_content = csv_file_bin.decode(csv_file_encoding).splitlines()
         delimiter = source.csv_delimiter
         quotechar = source.csv_quotechar
 


### PR DESCRIPTION
ping @simahawk @mmequignon 

Fix the following exception:
```python
  File "/odoo/external-src/connector-interfaces/connector_importer/models/recordset.py", line 287, in generate_report
    metadata, content = reporter.report_get(self)
  File "/odoo/external-src/connector-interfaces/connector_importer/models/reporter.py", line 30, in report_get
    self.report_do(recordset, fileout, **options)
  File "/odoo/external-src/connector-interfaces/connector_importer/models/reporter.py", line 139, in report_do
    orig_content = base64.b64decode(source.csv_file).decode().splitlines()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xdc in position 487: invalid continuation byte

```