### PR TITLE
[13.0] connector_importer: refactor import type conf, purge not needed values on write

### DIFF
--- a/connector_importer/__manifest__.py
+++ b/connector_importer/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Connector Importer",
     "summary": """This module takes care of import sessions.""",
-    "version": "13.0.1.4.1",
+    "version": "13.0.1.5.0",
     "depends": ["connector", "queue_job"],
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
@@ -24,5 +24,5 @@
         "views/source_config_template.xml",
         "menuitems.xml",
     ],
-    "external_dependencies": {"python": ["chardet", "pytz"]},
+    "external_dependencies": {"python": ["chardet", "pytz", "pyyaml"]},
 }

--- a/connector_importer/migrations/13.0.1.5.0/pre-migration.py
+++ b/connector_importer/migrations/13.0.1.5.0/pre-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2020 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+
+from odoo.tools.sql import drop_not_null
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    _logger.info("Drop import.type.settings contraint")
+    drop_not_null(cr, "import_type", "settings")

--- a/connector_importer/models/import_type.py
+++ b/connector_importer/models/import_type.py
@@ -2,22 +2,53 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, fields, models
+import logging
+
+from odoo import _, api, exceptions, fields, models
+from odoo.tools import DotDict
+
+_logger = logging.getLogger(__name__)
+
+
+try:
+    import yaml
+except ImportError:
+    _logger.debug("`yaml` lib is missing")
 
 
 class ImportType(models.Model):
     """Define an import.
 
     An import type describes what an recordset should do.
-    You can describe an import using the `settings` field.
+    You can describe an import using the `options` field with YAML format.
     Here you can declare what you want to import (model) and how (importer).
 
     Settings example:
 
-        product.template::template.importer.component.name
-        product.product::product.importer.component.name
+    - model: product.template
+      importer: template.importer.component.name
+      context:
+        key1: foo
+      # will be ignored
+      description: a nice import
+      options:
+        mapper:
+          one: False
+        tracking_handler:
+          one: False
 
-    Each line contains a couple model::importer.
+    - model: product.product
+      importer: product.importer.component.name
+      context:
+        key1: foo
+      # will be ignored
+      description: a nice import
+      options:
+        importer:
+          break_on_error: True
+        record_handler:
+          one: False
+
     The model is what you want to import, the importer states
     the name of the connector component to handle the import for that model.
 
@@ -30,9 +61,10 @@ class ImportType(models.Model):
 
     name = fields.Char(required=True, help="A meaningful human-friendly name")
     key = fields.Char(required=True, help="Unique mnemonic identifier")
+    options = fields.Text()
     settings = fields.Text(
-        string="Settings",
-        required=True,
+        string="Legacy Settings",
+        required=False,
         help="""
             # comment me
             product.template::template.importer.component.name
@@ -52,11 +84,64 @@ class ImportType(models.Model):
         default=True,
     )
     _sql_constraints = [
-        ("key_uniq", "unique (key)", _("Import type `key` must be unique!"))
+        ("key_uniq", "unique (key)", "Import type `key` must be unique!")
     ]
     # TODO: provide default source and configuration policy
     # for an import type to ease bootstrapping recordsets from UI.
     # default_source_model_id = fields.Many2one()
+
+    @api.constrains("options")
+    def _check_options(self):
+        no_options = self.browse()
+        for rec in self:
+            if not rec.options and not rec.settings:
+                no_options.append(rec)
+            # TODO: validate yaml schema (maybe w/ Cerberus?)
+        if no_options:
+            raise exceptions.UserError(
+                _("No options found for: {}.").format(
+                    ", ".join(no_options.mapped("name"))
+                )
+            )
+
+    def _load_options(self):
+        return yaml.safe_load(self.options or "") or []
+
+    def available_importers(self):
+        self.ensure_one()
+        if self.settings:
+            for item in self._legacy_available_importers():
+                yield item
+        options = self._load_options()
+        for line in options:
+            is_last_importer = False
+            if line == options[-1]:
+                is_last_importer = True
+            yield self._make_importer_info(line, is_last_importer=is_last_importer)
+
+    def _make_importer_info(self, line, is_last_importer=True):
+        """Prepare importer information.
+
+        :param line: dictionary representing a config line from `settings`
+        :param is_last_importer: boolean to state if the line represents the last one
+        :return: odoo.tools.DotDict instance containing all importer options.
+        """
+        res = DotDict(line, is_last_importer=is_last_importer)
+        if "options" not in res:
+            res["options"] = {}
+        if "context" not in res:
+            res["context"] = {}
+        for k in ("importer", "mapper", "record_handler", "tracking_handler"):
+            if k not in res.options:
+                res["options"][k] = {}
+        return res
+
+    # TODO: trash it for v14
+    def _legacy_available_importers(self):
+        for item in self.available_models():
+            yield self._make_importer_info(
+                {"model": item[0], "importer": item[1]}, is_last_importer=item[2]
+            )
 
     def available_models(self):
         """Retrieve available import models and their importers.
@@ -64,6 +149,7 @@ class ImportType(models.Model):
         Parse `settings` and yield a tuple
             `(model, importer, is_last_importer)`.
         """
+        _logger.warning("DEPRECATED legacy settings: move to JSON settings.")
         self.ensure_one()
         lines = self.settings.strip().splitlines()
         for _line in lines:

--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -157,13 +157,12 @@ class ImportRecordset(models.Model, JobRelatedMixin):
             "report_by_model": OrderedDict(),
         }
         # count keys by model
-        for item in self.available_models():
-            _model = item[0]
-            model = self.env["ir.model"]._get(_model)
+        for config in self.available_importers():
+            model = self.env["ir.model"]._get(config.model)
             data["report_by_model"][model] = {}
             # be defensive here. At some point
             # we could decide to skip models on demand.
-            for k, v in report.get(_model, {}).items():
+            for k, v in report.get(config.model, {}).items():
                 data["report_by_model"][model][k] = len(v)
         return data
 
@@ -204,8 +203,8 @@ class ImportRecordset(models.Model, JobRelatedMixin):
                 break
         return res
 
-    def available_models(self):
-        return self.import_type_id.available_models()
+    def available_importers(self):
+        return self.import_type_id.available_importers()
 
     @job(default_channel="root.connector_importer")
     def import_recordset(self):
@@ -264,11 +263,11 @@ class ImportRecordset(models.Model, JobRelatedMixin):
 
     def _get_importers(self):
         importers = OrderedDict()
-        for model_name, importer, __ in self.available_models():
-            model = self.env["ir.model"]._get(model_name)
+        for config in self.available_importers():
+            model = self.env["ir.model"]._get(config.model)
             with self.backend_id.work_on(self._name) as work:
                 importers[model] = work.component_by_name(
-                    importer, model_name=model_name
+                    config.importer, model_name=config.model
                 )
         return importers
 

--- a/connector_importer/readme/ROADMAP.rst
+++ b/connector_importer/readme/ROADMAP.rst
@@ -6,8 +6,9 @@
   lines it takes time to process them two times.
 * refactor the `recordset.full_report_url` field to return a QWeb report
   instead of a home-made HTML document + display it on the recordset form.
-* trigger an event at the end of the whole import (to be able to hook custom
-  behavior like move imported files on a remote filesystem).
 * move generic functions from `utils.mapper_utils` to the `connector` module
 * unit tests from `tests.test_source_csv` are not imported (Odoo ignores them)
   and they need to be fixed
+* unit tests for record handler and tracker
+* rely on `self.work.options` in all components to replace all custom flags
+  (eg: `_break_on_error`)

--- a/connector_importer/tests/test_import_type.py
+++ b/connector_importer/tests/test_import_type.py
@@ -2,7 +2,6 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-
 from psycopg2 import IntegrityError
 
 import odoo.tests.common as common
@@ -23,7 +22,8 @@ class TestImportType(common.SavepointCase):
                 {"name": "Duplicated Ok", "key": "ok", "settings": ""}
             )
 
-    def test_available_models(self):
+    def test_available_importers_legacy(self):
+        """Ensure old text-like settings work with new options."""
         itype = self.type_model.create(
             {
                 "name": "Ok",
@@ -38,13 +38,105 @@ class TestImportType(common.SavepointCase):
             """,
             }
         )
-        models = tuple(itype.available_models())
+        importers = tuple(itype.available_importers())
         self.assertEqual(
-            models,
+            importers,
             (
-                # model, importer, is_last_importer
-                ("res.partner", "partner.importer", False),
-                ("res.users", "user.importer", False),
-                ("another.one", "import.withspaces", True),
+                {
+                    "importer": "partner.importer",
+                    "model": "res.partner",
+                    "is_last_importer": False,
+                    "context": {},
+                    "options": {
+                        "importer": {},
+                        "mapper": {},
+                        "record_handler": {},
+                        "tracking_handler": {},
+                    },
+                },
+                {
+                    "importer": "user.importer",
+                    "model": "res.users",
+                    "is_last_importer": False,
+                    "context": {},
+                    "options": {
+                        "importer": {},
+                        "mapper": {},
+                        "record_handler": {},
+                        "tracking_handler": {},
+                    },
+                },
+                {
+                    "importer": "import.withspaces",
+                    "model": "another.one",
+                    "is_last_importer": True,
+                    "context": {},
+                    "options": {
+                        "importer": {},
+                        "mapper": {},
+                        "record_handler": {},
+                        "tracking_handler": {},
+                    },
+                },
             ),
+        )
+
+    def test_available_importers(self):
+        options = """
+        - model: res.partner
+          importer: partner.importer
+        - model: res.users
+          importer: user.importer
+          options:
+            importer:
+              baz: True
+            record_handler:
+              bar: False
+        - model: another.one
+          importer: import.withspaces
+          context:
+            foo: True
+        """
+        itype = self.type_model.create({"name": "Ok", "key": "ok", "options": options})
+        importers = tuple(itype.available_importers())
+        expected = (
+            {
+                "importer": "partner.importer",
+                "model": "res.partner",
+                "is_last_importer": False,
+                "context": {},
+                "options": {
+                    "importer": {},
+                    "mapper": {},
+                    "record_handler": {},
+                    "tracking_handler": {},
+                },
+            },
+            {
+                "importer": "user.importer",
+                "model": "res.users",
+                "is_last_importer": False,
+                "context": {},
+                "options": {
+                    "importer": {"baz": True},
+                    "mapper": {},
+                    "record_handler": {"bar": False},
+                    "tracking_handler": {},
+                },
+            },
+            {
+                "importer": "import.withspaces",
+                "model": "another.one",
+                "is_last_importer": True,
+                "context": {"foo": 1},
+                "options": {
+                    "importer": {},
+                    "mapper": {},
+                    "record_handler": {},
+                    "tracking_handler": {},
+                },
+            },
+        )
+        self.assertEqual(
+            importers, expected,
         )

--- a/connector_importer/tests/test_recordset.py
+++ b/connector_importer/tests/test_recordset.py
@@ -45,15 +45,11 @@ class TestRecordset(common.SavepointCase):
             self.recordset.backend_id.name + " #" + str(self.recordset.id),
         )
 
-    def test_available_models(self):
+    def test_available_importers(self):
         """Available models are propagated from import type."""
-        models = tuple(self.recordset.available_models())
         self.assertEqual(
-            models,
-            (
-                # model, importer, is_last_importer
-                ("res.partner", "partner.importer", True),
-            ),
+            tuple(self.recordset.available_importers()),
+            tuple(self.recordset.import_type_id.available_importers()),
         )
 
     def test_get_set_raw_report(self):


### PR DESCRIPTION
Introduce a more advanced way to configure import types using YAML.
This way you can define on the import type additional options for involved components.

```yaml
        - model: res.partner
          importer: partner.importer
        - model: res.users
          importer: user.importer
          options:
            importer:
              baz: True
            record_handler:
              bar: False
        - model: another.one
          importer: import.withspaces
          context:
            foo: True
```
From components you can then lookup options like `self.work.options.[mapper|record_handler|...]`.