### PR TITLE
[15.0][FIX] connector_importer: finish trigger in csv importer

### DIFF
--- a/connector_importer/components/importer_csv_std.py
+++ b/connector_importer/components/importer_csv_std.py
@@ -153,6 +153,7 @@ class RecordImporterCSVStd(Component):
         self._do_report()
 
         # log chunk finished
+        counters = self.tracker.get_counters()
         msg = " ".join(
             [
                 "CHUNK FINISHED",
@@ -161,10 +162,7 @@ class RecordImporterCSVStd(Component):
                 "[skipped: {skipped}]",
                 "[errored: {errored}]",
             ]
-        ).format(**self.tracker.get_counters())
+        ).format(**counters)
         self.tracker._log(msg)
-
-        # TODO
-        # chunk_finished_event.fire(
-        #     self.env, self.model._name, self.record)
-        return "ok"
+        self._trigger_finish_events(record, is_last_importer=is_last_importer)
+        return counters

--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -258,7 +258,7 @@ class ImportRecordset(models.Model):
         metadata, content = reporter.report_get(self)
         self.write(
             {
-                "report_file": base64.encodestring(content.encode()),
+                "report_file": base64.encodebytes(content.encode()),
                 "report_filename": metadata["complete_filename"],
             }
         )


### PR DESCRIPTION
- When using the RecordImporterCSVStd Component the post import action (moving files to the destination folder) does not work as the finish event ist not triggered there.
- The code to reply the counters is also taken from the base component code to make it behave accordingly.
- To get rid of deprecation warnings the base64.encodestring is also replaced with base64.encodebytes