### PR TITLE
[15.0][IMP] connector_importer: allow \t as delimiter

### DIFF
--- a/connector_importer/tests/test_source_csv.py
+++ b/connector_importer/tests/test_source_csv.py
@@ -93,3 +93,13 @@ class TestSourceCSV(BaseTestCase):
         self.assertItemsEqual(
             sorted(self.extra_fields), sorted(data["fields_info"].keys())
         )
+
+    @mute_logger("[importer]")
+    def test_source_with_escaped_tab(self):
+        # make sure an escaped tab is replaced with a real tab when updating
+        set_delimiter = {"csv_delimiter": "\\t"}
+        self.source.update(set_delimiter)
+        self.assertEqual(self.source.csv_delimiter, "\t")
+        # make also sure the escaped tab is replaced when creating a new source
+        new_source = self.env["import.source.csv"].create(set_delimiter)
+        self.assertEqual(new_source.csv_delimiter, "\t")


### PR DESCRIPTION
When a tab delimited file is uploaded, the delimiter character gets detected automatically and filled into the delimiter field. When using the importer with a fixed path (of sftp) instead it is not possible to enter a tab character into the input field (it is filtered and replaced with an empty string).
Proposing the possibility to enter '\t' there and replace it with a tab character internally (multi character delimiters are not allowed anyway).