### PR TITLE
[14.0] connector_importer: allow pass options to converter 

### DIFF
--- a/connector_importer/components/dynamicmapper.py
+++ b/connector_importer/components/dynamicmapper.py
@@ -113,11 +113,6 @@ class DynamicMapper(Component):
     def _source_key_prefix(self):
         return self.work.options.mapper.get("source_key_prefix", "")
 
-    @property
-    def _source_key_xid_module(self):
-        """Module name to use to sanitize XMLids"""
-        return self.work.options.mapper.get("source_key_xid_module", "")
-
     def _is_xmlid_key(self, fname, ftype):
         return fname.startswith("xid::") and ftype in (
             "many2one",
@@ -125,26 +120,25 @@ class DynamicMapper(Component):
             "many2many",
         )
 
-    def _dynamic_keys_mapping(self, fname):
+    def _dynamic_keys_mapping(self, fname, **options):
         return {
             "char": lambda self, rec, fname: rec[fname],
             "text": lambda self, rec, fname: rec[fname],
             "selection": lambda self, rec, fname: rec[fname],
-            "integer": convert(fname, "safe_int"),
-            "float": convert(fname, "safe_float"),
-            "boolean": convert(fname, "bool"),
-            "date": convert(fname, "date"),
-            "datetime": convert(fname, "utc_date"),
-            "many2one": backend_to_rel(fname),
-            "many2many": backend_to_rel(fname),
-            "one2many": backend_to_rel(fname),
-            "_xmlid": xmlid_to_rel(
-                fname, sanitize_default_mod_name=self._source_key_xid_module
-            ),
+            "integer": convert(fname, "safe_int", **options),
+            "float": convert(fname, "safe_float", **options),
+            "boolean": convert(fname, "bool", **options),
+            "date": convert(fname, "date", **options),
+            "datetime": convert(fname, "utc_date", **options),
+            "many2one": backend_to_rel(fname, **options),
+            "many2many": backend_to_rel(fname, **options),
+            "one2many": backend_to_rel(fname, **options),
+            "_xmlid": xmlid_to_rel(fname, **options),
         }
 
     def _get_converter(self, fname, ftype):
-        return self._dynamic_keys_mapping(fname).get(ftype)
+        options = self.work.options.mapper.get("converter", {}).get(fname, {})
+        return self._dynamic_keys_mapping(fname, **options).get(ftype)
 
     _non_mapped_keys_cache = None
 

--- a/connector_importer/utils/mapper_utils.py
+++ b/connector_importer/utils/mapper_utils.py
@@ -119,7 +119,7 @@ def convert(field, conv_type, fallback_field=None, pre_value_handler=None, **kw)
     return modifier
 
 
-def from_mapping(field, mapping, default_value=None):
+def from_mapping(field, mapping, default_value=None, **kw):
     """Convert the source value using a ``mapping`` of values."""
 
     def modifier(self, record, to_attr):
@@ -130,7 +130,7 @@ def from_mapping(field, mapping, default_value=None):
     return modifier
 
 
-def concat(field, separator=" ", handler=None):
+def concat(field, separator=" ", handler=None, **kw):
     """Concatenate values from different fields."""
 
     # TODO: `field` is actually a list of fields.
@@ -148,7 +148,7 @@ def concat(field, separator=" ", handler=None):
     return modifier
 
 
-def xmlid_to_rel(field, sanitize=True, sanitize_default_mod_name=None):
+def xmlid_to_rel(field, sanitize=True, sanitize_default_mod_name=None, **kw):
     """Convert xmlids source values to ids."""
     xmlid_to_rel._sanitize = sanitize
     xmlid_to_rel._sanitize_default_mod_name = sanitize_default_mod_name
@@ -206,6 +206,7 @@ def backend_to_rel(  # noqa: C901
     allowed_length=None,
     create_missing=False,
     create_missing_handler=None,
+    **kw
 ):
     """A modifier intended to be used on the ``direct`` mappings.
 


### PR DESCRIPTION
You can now pass options for specific fields converter via conf. If for instance, the model you are importing has a relation `partner_id` you can state that missing records must be created automatically.

Eg:
```
- model: product.product
  options:
    importer:
      odoo_unique_key: barcode
    mapper:
      name: product.product.mapper
      converter:
        categ_id:
          create_missing: true
``` 

All the keys inside converted/field will be propagated to the `backend_to_rel` converter.