### PR TITLE
[14.0] c_importer: allow ctx key via options

### DIFF
--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -291,13 +291,14 @@ class RecordImporter(Component):
         """Retrieve mapper options."""
         return {"override_existing": self.must_override_existing}
 
-    # TODO: make these contexts customizable via recordset settings
     def _odoo_default_context(self):
         """Default context to be used in both create and write methods"""
-        return {
+        ctx = {
             "importer_type_id": self.recordset.import_type_id.id,
             "tracking_disable": True,
         }
+        ctx.update(self.work.options.importer.get("ctx", {}))
+        return ctx
 
     def _odoo_create_context(self):
         """Inject context variables on create, merged by odoorecord handler."""

--- a/connector_importer/tests/test_record_importer_basic.py
+++ b/connector_importer/tests/test_record_importer_basic.py
@@ -18,11 +18,12 @@ class TestRecordImporter(TestImporterBase):
 
         return [PartnerRecordImporter, PartnerMapper]
 
-    def _get_importer(self):
+    def _get_importer(self, options=None):
+        options = options or {"importer": {}, "mapper": {}}
         with self.backend.work_on(
             self.record._name,
             components_registry=self.comp_registry,
-            options=DotDict({"importer": {}, "mapper": {}}),
+            options=DotDict(options),
         ) as work:
             return work.component(usage="record.importer", model_name="res.partner")
 
@@ -103,3 +104,18 @@ class TestRecordImporter(TestImporterBase):
         importer._mapper_name = "fake.partner.mapper"
         mapper = importer._get_mapper()
         self.assertEqual(mapper._name, "fake.partner.mapper")
+
+    def test_importer_context(self):
+        importer = self._get_importer(
+            options={"importer": {"ctx": {"key1": 1, "key2": 2}}, "mapper": {}}
+        )
+        importer._init_importer(self.recordset)
+        self.assertEqual(
+            importer._odoo_create_context(),
+            {
+                "importer_type_id": self.recordset.import_type_id.id,
+                "tracking_disable": True,
+                "key1": 1,
+                "key2": 2,
+            },
+        )


### PR DESCRIPTION
You can now pass any context key to the importer (propagated to the record handler)

by using 'ctx' key in the 'importer' options.