### PR TITLE
[14.0] c_importer: fix recordset direct creation

### DIFF
--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -275,7 +275,7 @@ class ImportRecordset(models.Model):
         return res
 
     def available_importers(self):
-        return self.import_type_id.available_importers()
+        return self.import_type_id.available_importers() if self.import_type_id else ()
 
     def import_recordset(self):
         """This job will import a recordset."""

--- a/connector_importer/views/backend_views.xml
+++ b/connector_importer/views/backend_views.xml
@@ -74,7 +74,11 @@
                     </group>
                     <notebook>
                         <page string="Recordsets">
-                            <field name="recordset_ids" nolabel="1">
+                            <field
+                                name="recordset_ids"
+                                nolabel="1"
+                                context="{'default_backend_id': active_id}"
+                            >
                                 <tree>
                                     <field name="sequence" widget="handle" />
                                     <field name="name" readonly="1" />

--- a/connector_importer/views/recordset_views.xml
+++ b/connector_importer/views/recordset_views.xml
@@ -9,6 +9,12 @@
                 <group col="4" name="main">
                     <group colspan="2" name="base" string="Base configuration">
                         <field name="name" readonly="1" />
+                        <field
+                            name="backend_id"
+                            options="{'no_create': True}"
+                            invisible="context.get('default_backend_id')"
+                            required="1"
+                        />
                         <field name="import_type_id" options="{'no_create': True}" />
                         <field name="override_existing" />
                     </group>


### PR DESCRIPTION
Was broken because available_importers requires an import type which is not available before editing. It was also impossible to set the backend directly.