### PR TITLE
[14.0][FIX] connector_importer: skip_fields_unchanged

### DIFF
--- a/connector_importer/components/odoorecord.py
+++ b/connector_importer/components/odoorecord.py
@@ -229,7 +229,9 @@ class OdooRecordHandler(Component):
         # remove fields having the same value
         field_names = tuple(values.keys())
         if self.work.options.record_handler.skip_fields_unchanged:
-            current_values = odoo_record.read(field_names, load="_classic_write")
+            current_values = odoo_record.read(field_names, load="_classic_write")[0]
+            current_values.pop("id")
             for k, v in current_values.items():
-                if values[k] != v:
+                # FIXME: New value can be "1" and existing 1. Needs field conversion
+                if values[k] == v:
                     values.pop(k)


### PR DESCRIPTION
When `skip_fields_unchanged` is set for the record handler, the behaviour comparing existing with new values raises an error because `read` returns a list and another one, that `id` is not in `values`. 
And the operator is wrong. Currently it would import the values only if they are the same as the existing.

I added a FIXME for later to convert the new values. Is this ok?