### PR TITLE
[16.0][FIX] connector_importer: define serialized fields as binary

### DIFF
--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -2,12 +2,13 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import base64
+import json
 import os
 from collections import OrderedDict
 
 from odoo import api, fields, models
 
-from odoo.addons.base_sparse_field.models.fields import Serialized
 from odoo.addons.component.utils import is_component_registry_ready
 from odoo.addons.queue_job.job import DONE, STATES
 
@@ -64,8 +65,8 @@ class ImportRecordset(models.Model):
     create_date = fields.Datetime()
     record_ids = fields.One2many("import.record", "recordset_id", string="Records")
     # store info about imports report
-    report_data = Serialized()
-    shared_data = Serialized()
+    report_data = fields.Binary(attachment=True)
+    shared_data = fields.Binary(attachment=True)
     report_html = fields.Html("Report summary", compute="_compute_report_html")
     full_report_url = fields.Char(compute="_compute_full_report_url")
     jobs_global_state = fields.Selection(
@@ -141,9 +142,14 @@ class ImportRecordset(models.Model):
         """Update serialized data."""
         _values = {}
         if not reset:
-            _values = self[fname]
+            _values = getattr(self, fname) or {}
+            if _values:
+                _values = self._get_json_from_binary(_values)
+
         _values.update(values)
-        self[fname] = _values
+        json_report_data = json.dumps(_values)
+        _values = base64.b64encode(bytes(json_report_data, "utf-8"))
+        setattr(self, fname, _values)
         # Without invalidating cache we will have a bug because of Serialized
         # field in odoo. It uses json.loads on convert_to_cache, which leads
         # to all of our int dict keys converted to strings. Except for the
@@ -160,9 +166,19 @@ class ImportRecordset(models.Model):
         self.ensure_one()
         self._set_serialized("report_data", values, reset=reset)
 
+    def _get_json_from_binary(self, binary_data):
+        json_raw_data = {}
+        if binary_data:
+            json_raw_data = base64.b64decode(binary_data).decode("utf-8")
+            json_raw_data = json.loads(json_raw_data)
+        return json_raw_data
+
     def get_report(self):
         self.ensure_one()
-        return self.report_data or {}
+        json_raw_data = self._get_json_from_binary(
+            self.with_context(bin_size=False).report_data
+        )
+        return json_raw_data
 
     def set_shared(self, values, reset=False):
         """Update import report values."""
@@ -171,7 +187,10 @@ class ImportRecordset(models.Model):
 
     def get_shared(self):
         self.ensure_one()
-        return self.shared_data or {}
+        json_raw_data = self._get_json_from_binary(
+            self.with_context(bin_size=False).shared_data
+        )
+        return json_raw_data
 
     def _prepare_for_import_session(self, start=True):
         """Wipe all session related data."""
@@ -180,9 +199,10 @@ class ImportRecordset(models.Model):
             report_data["_last_start"] = fields.Datetime.to_string(
                 fields.Datetime.now()
             )
+        json_report_data = json.dumps(report_data)
         values = {
             "record_ids": [(5, 0, 0)],
-            "report_data": report_data,
+            "report_data": base64.b64encode(bytes(json_report_data, "utf-8")),
             "shared_data": {},
         }
         self.write(values)

--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -150,6 +150,19 @@ class ImportRecordset(models.Model):
         json_report_data = json.dumps(_values)
         _values = base64.b64encode(bytes(json_report_data, "utf-8"))
         setattr(self, fname, _values)
+        # We need to invalidate the cache because the context dict
+        # bin_size=False triggers the _compute_datas(self) method
+        # which has the @api.depends_context('bin_size') decorator.
+        # Flush all pending computations and updates to the database.
+        domain = [
+            ("res_model", "=", self._name),
+            ("res_field", "=", fname),
+            ("res_id", "in", self.ids),
+        ]
+        attachments = self.env["ir.attachment"].sudo().search(domain)
+        if attachments:
+            attachments.invalidate_recordset(("datas", "raw"))
+
         # Without invalidating cache we will have a bug because of Serialized
         # field in odoo. It uses json.loads on convert_to_cache, which leads
         # to all of our int dict keys converted to strings. Except for the


### PR DESCRIPTION
This PR replaces the use of Serialized fields with Binary fields for report_data and shared_data in the ImportRecordset model. This change aims to improve performance and provide better storage management for large datasets.

_"We have an issue with the way the report json is stored in a Serialized field import.recordset::report_data.  The data we send in there can be in the MB order of magnitude, and this will kill postgresql + kill Loki on the cloud platform (because a failure to execute the SQL UPDATE to store the huge JSON will be logged, with the full JSON document, producing a single log line of several MB… )"_