### PR TITLE
[FIX][14.0] connector_importer: Respect debug mode and use_job parameter

### DIFF
--- a/connector_importer/tests/test_record_importer.py
+++ b/connector_importer/tests/test_record_importer.py
@@ -42,10 +42,30 @@ class TestRecordImporter(TestImporterBase):
         expected = {
             model: {"created": 10, "errored": 0, "updated": 0, "skipped": 0},
         }
-        delayable = res[model]
-        self.assertEqual(delayable.result, expected[model])
+        result = res[model]
+        self.assertEqual(result, expected[model])
         for k, v in expected[model].items():
             self.assertEqual(len(report[model][k]), v)
+        self.assertEqual(self.env[model].search_count([("ref", "like", "id_%")]), 10)
+
+    @mute_logger("[importer]")
+    def test_importer_create_debug_mode_off(self):
+        # set them on record
+        self.record.set_data(self.fake_lines)
+        self.record.backend_id.debug_mode = False
+        res = self.record._run_import(use_job=True)
+        self.recordset.get_report()
+        # in any case we'll get this per each model if the import is not broken
+        model = "res.partner"
+        expected = {
+            model: {"created": 10, "errored": 0, "updated": 0, "skipped": 0},
+        }
+        delayable = res[model]
+        result = delayable.perform()
+        self.assertEqual(result, expected[model])
+        result = {model: result}
+        for k, v in expected[model].items():
+            self.assertEqual(result[model][k], v)
         self.assertEqual(self.env[model].search_count([("ref", "like", "id_%")]), 10)
 
     @mute_logger("[importer]")
@@ -61,8 +81,8 @@ class TestRecordImporter(TestImporterBase):
         report = self.recordset.get_report()
         model = "res.partner"
         expected = {model: {"created": 8, "errored": 0, "updated": 0, "skipped": 2}}
-        delayable = res[model]
-        self.assertEqual(delayable.result, expected[model])
+        result = res[model]
+        self.assertEqual(result, expected[model])
         for k, v in expected[model].items():
             self.assertEqual(len(report[model][k]), v)
         skipped_msg1 = report[model]["skipped"][0]["message"]
@@ -82,8 +102,8 @@ class TestRecordImporter(TestImporterBase):
         report = self.recordset.get_report()
         model = "res.partner"
         expected = {model: {"created": 10, "errored": 0, "updated": 0, "skipped": 0}}
-        delayable = res[model]
-        self.assertEqual(delayable.result, expected[model])
+        result = res[model]
+        self.assertEqual(result, expected[model])
         for k, v in expected[model].items():
             self.assertEqual(len(report[model][k]), v)
         # now run it a second time
@@ -93,8 +113,8 @@ class TestRecordImporter(TestImporterBase):
         res = self.record.run_import()
         report = self.recordset.get_report()
         expected = {model: {"created": 0, "errored": 0, "updated": 10, "skipped": 0}}
-        delayable = res[model]
-        self.assertEqual(delayable.result, expected[model])
+        result = res[model]
+        self.assertEqual(result, expected[model])
         for k, v in expected[model].items():
             self.assertEqual(len(report[model][k]), v)
         # now run it a second time
@@ -104,8 +124,8 @@ class TestRecordImporter(TestImporterBase):
         res = self.record.run_import()
         report = self.recordset.get_report()
         expected = {model: {"created": 0, "errored": 0, "updated": 0, "skipped": 10}}
-        delayable = res[model]
-        self.assertEqual(delayable.result, expected[model])
+        result = res[model]
+        self.assertEqual(result, expected[model])
         for k, v in expected[model].items():
             self.assertEqual(len(report[model][k]), v)
         skipped_msg1 = report[model]["skipped"][0]["message"]

--- a/connector_importer/tests/test_record_importer_xmlid.py
+++ b/connector_importer/tests/test_record_importer_xmlid.py
@@ -46,8 +46,8 @@ class TestRecordImporterXMLID(TestImporterBase):
         report = self.recordset.get_report()
         model = "res.partner"
         expected = {model: {"created": 10, "errored": 0, "updated": 0, "skipped": 0}}
-        delayable = res[model]
-        self.assertEqual(delayable.result, expected[model])
+        result = res[model]
+        self.assertEqual(result, expected[model])
         for k, v in expected[model].items():
             self.assertEqual(len(report[model][k]), v)
         self.assertEqual(self.env[model].search_count([("ref", "like", "id_%")]), 10)


### PR DESCRIPTION
connector_importer: Improve _run_import method to respect debug mode and use_job parameter

- Handle debug mode separately
- Spawn jobs only when requested based on use_job parameter
