### PR TITLE
[18.0][PERF] connector_importer: add job_id index

### DIFF
--- a/connector_importer/models/job_mixin.py
+++ b/connector_importer/models/job_mixin.py
@@ -13,7 +13,7 @@ class JobRelatedMixin(models.AbstractModel):
     _name = "job.related.mixin"
     _description = __doc__
 
-    job_id = fields.Many2one("queue.job", string="Job", readonly=True)
+    job_id = fields.Many2one("queue.job", string="Job", readonly=True, index=True)
     job_state = fields.Selection(index=True, related="job_id.state")
 
     def has_job(self):


### PR DESCRIPTION
Add index on job_id in job.related.mixin to allow to delete a queue job without causing a full scan

Port to 18.0:
- [ ] https://github.com/OCA/connector-interfaces/pull/150