### PR TITLE
[FIX][18.0] connector_importer: take full control of what are the required_keys

### DIFF
--- a/connector_importer/components/mapper.py
+++ b/connector_importer/components/mapper.py
@@ -54,7 +54,15 @@ class ImportMapper(Component):
         """
         req = dict(self.required)
         req.update(self.work.options.mapper.get("required_keys", {}))
+
+        if self.required_keys_ignore_mapper:
+            req = self.work.options.mapper.get("required_keys", {})
+
         return req
+
+    @property
+    def required_keys_ignore_mapper(self):
+        return self.work.options.mapper.get("required_keys_ignore_mapper", False)
 
     translatable = []
 

--- a/connector_importer/components/mapper.py
+++ b/connector_importer/components/mapper.py
@@ -53,10 +53,11 @@ class ImportMapper(Component):
         The recordset will use this to show required fields to users.
         """
         req = dict(self.required)
-        req.update(self.work.options.mapper.get("required_keys", {}))
 
         if self.required_keys_ignore_mapper:
             req = self.work.options.mapper.get("required_keys", {})
+        else:
+            req.update(self.work.options.mapper.get("required_keys", {}))
 
         return req
 


### PR DESCRIPTION
connector_importer: take full control of what are the required_keys
Not forcing required default value if required_keys_ignore_mapper and required_keys are defined in options.mapper. Adding the new property required_keys_ignore_mapper in order to override the result of required_keys function


Commit ported from the following fix https://github.com/OCA/connector-interfaces/pull/141/commits to V18