### PR TITLE
[FIX][18.0] connector_importer: allow sudo for the user to access `ir.ui.view` model

### DIFF
--- a/connector_importer/models/sources/source_mixin.py
+++ b/connector_importer/models/sources/source_mixin.py
@@ -117,7 +117,7 @@ class ImportSource(models.AbstractModel):
         return self.get_formview_id()
     
     def get_formview_id(self, access_uid=None):
-        return self.env["ir.ui.view"].default_view(self._name, "form") or False
+        return self.env["ir.ui.view"].sudo().default_view(self._name, "form") or False
 
     def get_reporter(self):
         """Retrieve a specific reporter for this source.

--- a/connector_importer/models/sources/source_mixin.py
+++ b/connector_importer/models/sources/source_mixin.py
@@ -113,14 +113,11 @@ class ImportSource(models.AbstractModel):
 
     def get_config_view_id(self):
         """Retrieve configuration view."""
-        # Allow sudo to access ``ir.ui.view`` while
-        # the user with ``group_connector_manager`` may not have access to it.
-        return (
-            self.env["ir.ui.view"]
-            .sudo()
-            .search([("model", "=", self._name), ("type", "=", "form")], limit=1)
-            .id
-        )
+        # DEPRECATED, use get_formview_id instead
+        return self.get_formview_id()
+    
+    def get_formview_id(self, access_uid=None):
+        return self.env["ir.ui.view"].default_view(self._name, "form") or False
 
     def get_reporter(self):
         """Retrieve a specific reporter for this source.

--- a/connector_importer/models/sources/source_mixin.py
+++ b/connector_importer/models/sources/source_mixin.py
@@ -113,8 +113,11 @@ class ImportSource(models.AbstractModel):
 
     def get_config_view_id(self):
         """Retrieve configuration view."""
+        # Allow sudo to access ``ir.ui.view`` while
+        # the user with ``group_connector_manager`` may not have access to it.
         return (
             self.env["ir.ui.view"]
+            .sudo()
             .search([("model", "=", self._name), ("type", "=", "form")], limit=1)
             .id
         )


### PR DESCRIPTION
To access `ir.ui.view` model records the user should have `Administration\Settings::base.group_system` group assigned.
While the `connector.group_connector_manager` and `connector_importer.group_importer_user` don't have such rights.

To reproduce:
1. Go to "Import recordsets" => "Import recordset" => click "Configure source" button.
2. The `open_source_config` method calls `get_config_view_id` to fetch the requested view.
3. An access error is raised.

```
odoo.http: You are not allowed to access 'View' (ir.ui.view) records.
This operation is allowed for the following groups:
	- Administration/Settings
```
