### PR TITLE
[18.0] [IMP] connector_importer: log exception

### DIFF
--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -343,6 +343,7 @@ class RecordImporter(Component):
                     values = self.mapper.map_record(line).values(**options)
                 logger.debug(values)
             except Exception as err:
+                logger.exception(err)
                 values = {}
                 self.tracker.log_error(values, line, odoo_record, message=err)
                 if self.must_break_on_error:

--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -345,7 +345,8 @@ class RecordImporter(Component):
             except Exception as err:
                 logger.exception(err)
                 values = {}
-                self.tracker.log_error(values, line, odoo_record, message=err)
+                message = f"{type(err).__name__}: {str(err)}"
+                self.tracker.log_error(values, line, odoo_record, message=message)
                 if self.must_break_on_error:
                     raise
                 continue


### PR DESCRIPTION
This PR includes two improvements in exception logging:

1. Exceptions are actually logged with a complete traceback, making it easier to debug
2. Tracked exception messages now include the exception type

For example, it would store `KeyError: 'something'` instead of just `'something'`