### PR TITLE
[18.0] [FIX] connector_importer: KeyError. "required" key is optional

### DIFF
--- a/connector_importer/components/dynamicmapper.py
+++ b/connector_importer/components/dynamicmapper.py
@@ -142,7 +142,7 @@ class DynamicMapper(Component):
         return tuple(valid_keys)
 
     def _required_keys(self):
-        return [k for k, v in self.model.fields_get().items() if v["required"]]
+        return [k for k, v in self.model.fields_get().items() if v.get("required")]
 
     @property
     def _source_key_whitelist(self):


### PR DESCRIPTION
Solves this traceback:

```python-traceback
2025-11-06 18:05:46,305 270 ERROR odoodb [importer]: 'required' 
Traceback (most recent call last):
  File ".../connector-interfaces/connector_importer/components/importer.py", line 343, in run
    values = self.mapper.map_record(line).values(**options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../connector/connector/components/mapper.py", line 1016, in values
    values = self._mapper._apply(self, options=options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../connector/connector/components/mapper.py", line 786, in _apply
    return self._apply_with_options(map_record)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../connector/connector/components/mapper.py", line 825, in _apply_with_options
    values = meth(map_record.source)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File ".../connector-interfaces/connector_importer/components/dynamicmapper.py", line 75, in dynamic_fields
    required_keys = self._required_keys()
                    ^^^^^^^^^^^^^^^^^^^^^
  File ".../connector-interfaces/connector_importer/components/dynamicmapper.py", line 145, in _required_keys
    return [k for k, v in self.model.fields_get().items() if v["required"]]
```