### PR TITLE
[18.0] [FIX] connector_importer: use the original value for the unique key if not mapped

### DIFF
--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -234,7 +234,8 @@ class RecordImporter(Component):
         ):
             msg = "ALREADY EXISTS"
             if self.unique_key:
-                msg += f": {self.unique_key}={values[self.unique_key]}"
+                key = values.get(self.unique_key) or orig_values.get(self.unique_key)
+                msg += f": {self.unique_key}={key}"
             return {
                 "message": msg,
                 "odoo_record": self.record_handler.odoo_find(values, orig_values).id,

--- a/connector_importer/tests/test_record_importer_basic.py
+++ b/connector_importer/tests/test_record_importer_basic.py
@@ -2,9 +2,17 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from textwrap import dedent
+
+from odoo.tests import RecordCapturer
 from odoo.tools import DotDict, mute_logger
 
 from .common import TestImporterBase
+
+LOGGERS_TO_MUTE = (
+    "[importer]",
+    "odoo.addons.queue_job.utils",
+)
 
 
 class TestRecordImporter(TestImporterBase):
@@ -120,3 +128,56 @@ class TestRecordImporter(TestImporterBase):
                 "key2": 2,
             },
         )
+
+    @mute_logger(*LOGGERS_TO_MUTE)
+    def test_importer_create_and_update(self):
+        self.import_type.write(
+            {
+                "options": dedent(
+                    """
+                    - model: res.partner
+                      options:
+                        importer:
+                          odoo_unique_key: id
+                          override_existing: false
+                          break_on_error: true
+                        mapper:
+                          name: importer.mapper.dynamic
+                    """
+                ),
+            }
+        )
+        # generate 10 records
+        count = 10
+        lines = self._fake_lines(count, keys=("id", "name"))
+        # Make sure id is an XML-id for all lines
+        for line in lines:
+            line["id"] = f"__import__.{line['id']}"
+        # set them on record
+        self.record.set_data(lines)
+        with RecordCapturer(self.env["res.partner"].sudo(), []) as rc:
+            res = self.record.run_import()
+        records = rc.records
+        # Check created records
+        self.assertEqual(len(records), 10)
+        # Check response
+        expected = {
+            "res.partner": {"created": 10, "errored": 0, "updated": 0, "skipped": 0}
+        }
+        self.assertEqual(res, expected)
+        # Check XML-IDs
+        for i in range(1, count + 1):
+            partner = self.env.ref(f"__import__.id_{i}", raise_if_not_found=False)
+            self.assertTrue(partner)
+        # Now update them
+        self.recordset.override_existing = False
+        self.record.set_data(lines)
+        with RecordCapturer(self.env["res.partner"].sudo(), []) as rc:
+            res = self.record.run_import()
+        # Check no created records
+        self.assertFalse(rc.records)
+        # Check response
+        expected = {
+            "res.partner": {"created": 0, "errored": 0, "updated": 0, "skipped": 10}
+        }
+        self.assertEqual(res, expected)


### PR DESCRIPTION
Using options like this:
```
- model: res.country
  options:
    importer:
      odoo_unique_key: id
      override_existing: false
      break_on_error: true
    mapper:
      name: importer.mapper.dynamic
```

And a sample file like this:
```
id;code;name
base.af;AF;Afghanistan
```


```python-trackeback
  File ".../connector-interfaces/connector_importer/models/record.py", line 94, in import_record
    return importer.run(
           ^^^^^^^^^^^^^
  File ".../connector-interfaces/connector_importer/components/importer.py", line 355, in run
    skip_info = self.skip_it(values, line)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../connector-interfaces/connector_importer/components/importer.py", line 237, in skip_it
    msg += f": {self.unique_key}={values[self.unique_key]}"
                                  ~~~~~~^^^^^^^^^^^^^^^^^
KeyError: 'id'
```