### PR TITLE
[18.0] [FIX] connector_importer: the import all button should be visible

### DIFF
--- a/connector_importer/views/backend_views.xml
+++ b/connector_importer/views/backend_views.xml
@@ -14,7 +14,7 @@
                             type="object"
                             string="Import all"
                             confirm="You are about to run ALL configured recordsets. Are you sure?"
-                            invisible="job_running or debug_mode == False"
+                            invisible="job_running and not debug_mode"
                         />
                         <button
                             class="oe_stat_button"


### PR DESCRIPTION
The button must be visible if no jobs are running or if we are in debug mode. The conditions were wrong, making it only visible for debug mode.