### PR TITLE
[18.0] [IMP]  connector_importer: handle empty values in dynamicmapper

### DIFF
--- a/connector_importer/components/dynamicmapper.py
+++ b/connector_importer/components/dynamicmapper.py
@@ -70,31 +70,22 @@ class DynamicMapper(Component):
         model = self.work.model_name
         vals = {}
         available_fields = self.env[model].fields_get()
-        prefix = self._source_key_prefix
         clean_record = self._clean_record(record)
         required_keys = self._required_keys()
         missing_required_keys = []
         for source_fname in self._non_mapped_keys(clean_record):
-            if source_fname in ("id", "xid::id") or source_fname.startswith("_"):
-                # Never convert IDs
+            # Special key, not mapped (ie: _line_nr)
+            if source_fname.startswith("_"):
                 continue
-            fname = source_fname
-            if "::" in fname:
-                # Eg: transformers like `xid::``
-                fname = fname.split("::")[-1]
-                clean_record[fname] = clean_record.pop(source_fname)
-            if fname.endswith("/id"):
-                # that's an xmlid key
-                fname = fname[:-3]
-                clean_record[fname] = clean_record.pop(source_fname)
-            if prefix and fname.startswith(prefix):
-                # Eg: prefix all supplier fields w/ `supplier.`
-                fname = fname[len(prefix) :]
-                clean_record[fname] = clean_record.pop(prefix + fname)
-            final_fname = self._get_field_name(fname, clean_record)
-            if final_fname != fname:
-                clean_record[final_fname] = clean_record.pop(fname)
-                fname = final_fname
+
+            # Translatable columns handled in collect_translatable
+            if (
+                ":" in source_fname
+                and source_fname.split(":")[0] in self.translatable_keys()
+            ):
+                continue
+
+            fname = self._map_special_key(clean_record, source_fname)
 
             if fname not in available_fields:
                 logger.warning("Field `%s` not found in model `%s`", fname, model)
@@ -134,6 +125,42 @@ class DynamicMapper(Component):
                     # and that cannot be emptied.
                     vals.pop(k)
         return vals
+
+    def _map_special_key(self, clean_record: dict, source_fname: str) -> str:
+        """Map special keys to the final field name.
+
+        This method handles the following special cases:
+        - IDs
+        - XMLIDs
+        - Prefixes
+        - Renames
+
+        It will modify the `clean_record` dictionary in place, and return the
+        mapped field name.
+
+        :param clean_record: the cleaned record values
+        :param source_fname: the source field name to map
+        :return: the final field name
+        """
+        fname = source_fname
+        if "::" in fname:
+            # Eg: transformers like `xid::``
+            fname = fname.split("::")[-1]
+            clean_record[fname] = clean_record.pop(source_fname)
+        if fname.endswith("/id"):
+            # that's an xmlid key
+            fname = fname[:-3]
+            clean_record[fname] = clean_record.pop(source_fname)
+        prefix = self._source_key_prefix
+        if prefix and fname.startswith(prefix):
+            # Eg: prefix all supplier fields w/ `supplier.`
+            fname = fname[len(prefix) :]
+            clean_record[fname] = clean_record.pop(prefix + fname)
+        final_fname = self._get_field_name(fname, clean_record)
+        if final_fname != fname:
+            clean_record[final_fname] = clean_record.pop(fname)
+            fname = final_fname
+        return fname
 
     def _clean_record(self, record):
         valid_keys = self._get_valid_keys(record)

--- a/connector_importer/components/dynamicmapper.py
+++ b/connector_importer/components/dynamicmapper.py
@@ -96,7 +96,14 @@ class DynamicMapper(Component):
                 clean_record[final_fname] = clean_record.pop(fname)
                 fname = final_fname
 
-            if available_fields.get(fname):
+            if fname not in available_fields:
+                logger.warning("Field `%s` not found in model `%s`", fname, model)
+                continue
+
+            # If the value is empty, simply set to False
+            # Otherwise, convert it to the appropriate type
+            value = False
+            if clean_record[fname]:
                 fspec = available_fields.get(fname)
                 ftype = fspec["type"]
                 if self._is_xmlid_key(source_fname, ftype):
@@ -104,16 +111,20 @@ class DynamicMapper(Component):
                 converter = self._get_converter(fname, ftype)
                 if converter:
                     value = converter(self, clean_record, fname)
-                    if not value:
-                        if source_fname in self._source_key_empty_skip:
-                            continue
-                        if fname in required_keys:
-                            missing_required_keys.append(fname)
-                    vals[fname] = value
                 else:
                     logger.debug(
-                        "Dynamic mapper cannot find converte for field `%s`", fname
+                        "Dynamic mapper cannot find converter for field `%s`", fname
                     )
+
+            # If there's no value, handle skip empty or required keys
+            if not value:
+                if source_fname in self._source_key_empty_skip:
+                    continue
+                if fname in required_keys:
+                    missing_required_keys.append(fname)
+
+            vals[fname] = value
+
         if missing_required_keys:
             vals.update(self._get_defaults(missing_required_keys))
             for k in missing_required_keys:

--- a/connector_importer/tests/test_mapper.py
+++ b/connector_importer/tests/test_mapper.py
@@ -168,6 +168,18 @@ class TestRecordsetImporter(TestImporterBase):
         }
         self.assertEqual(mapper.dynamic_fields(rec), expected)
 
+    def test_dynamic_mapper_empty_value(self):
+        mapper = self._get_dynamyc_mapper()
+        rec = {
+            "name": "John Doe",
+            "ref": "",
+        }
+        expected = {
+            "name": "John Doe",
+            "ref": False,
+        }
+        self.assertEqual(mapper.dynamic_fields(rec), expected)
+
     def test_dynamic_mapper_skip_empty(self):
         rec = {
             "name": "John Doe",

--- a/connector_importer/tests/test_mapper.py
+++ b/connector_importer/tests/test_mapper.py
@@ -119,13 +119,14 @@ class TestRecordsetImporter(TestImporterBase):
             "xid::category_id": """
                 base.res_partner_category_0,base.res_partner_category_2
             """,
-            "title_id": "Doctor",
+            "title": "Doctor",
         }
         expected = {
             "name": "John Doe",
             "ref": "12345",
             "parent_id": self.env.ref("base.res_partner_10").id,
             "category_id": [(6, 0, categs.ids)],
+            "title": self.env.ref("base.res_partner_title_doctor").id,
         }
         self.assertEqual(mapper.dynamic_fields(rec), expected)
 


### PR DESCRIPTION
Empty values in the source must be treated as `False` to be aligned with Odoo's ORM.

For example, 'ref': '' must be treated as `False`, which translates to a NULL value in the database.

Otherwise, the value is set to an empty string, which is a bit unexpected by the ORM, and may cause unexpected behaviors like UNIQUE constraint violations, usually not possible to reproduce with standard Odoo's flow