### PR TITLE
[18.0] [IMP] connector_importer: supress debug_mode warning during tests

### DIFF
--- a/connector_importer/models/record.py
+++ b/connector_importer/models/record.py
@@ -5,6 +5,7 @@
 import base64
 import json
 import os
+import threading
 
 from odoo import api, fields, models
 
@@ -75,7 +76,9 @@ class ImportRecord(models.Model):
     def _should_use_jobs(self):
         self.ensure_one()
         debug_mode = self.debug_mode()
-        if debug_mode:
+        if debug_mode and not getattr(
+            threading.current_thread(), "testing", False
+        ):  # pragma: no cover
             logger.warning("### DEBUG MODE ACTIVE: WILL NOT USE QUEUE ###")
         use_job = self.recordset_id.import_type_id.use_job
         if debug_mode:

--- a/connector_importer/models/recordset.py
+++ b/connector_importer/models/recordset.py
@@ -5,6 +5,7 @@
 import base64
 import json
 import os
+import threading
 from collections import OrderedDict
 
 from odoo import api, fields, models
@@ -321,7 +322,10 @@ class ImportRecordset(models.Model):
         """queue a job for creating records (import.record items)"""
         job_method = self.with_delay().import_recordset
         if self.debug_mode():
-            logger.warning("### DEBUG MODE ACTIVE: WILL NOT USE QUEUE ###")
+            if not getattr(
+                threading.current_thread(), "testing", False
+            ):  # pragma: no cover
+                logger.warning("### DEBUG MODE ACTIVE: WILL NOT USE QUEUE ###")
             job_method = self.import_recordset
 
         for item in self:


### PR DESCRIPTION
It's just annoying.

We could use `mute_logger`, but it would suppress everything.
I only want to suppress this warning