### PR TITLE
[18.0] Fix missing sudo() on ir.model.data creation

### DIFF
--- a/connector_importer/components/odoorecord.py
+++ b/connector_importer/components/odoorecord.py
@@ -163,7 +163,7 @@ class OdooRecordHandler(Component):
             xid = self._get_xmlid(values_for_create, orig_values)
             if not self.env.ref(xid, raise_if_not_found=False):
                 module, id_ = xid.split(".", 1)
-                self.env["ir.model.data"].create(
+                self.env["ir.model.data"].sudo().create(
                     {
                         "name": id_,
                         "module": module,

--- a/connector_importer_product/components/product_product/record_handler.py
+++ b/connector_importer_product/components/product_product/record_handler.py
@@ -63,7 +63,7 @@ class ProductProductRecordHandler(Component):
             tmpl_xid = sanitize_external_id(orig_values.get("xid::product_tmpl_id"))
             if not self.env.ref(tmpl_xid, raise_if_not_found=False):
                 module, id_ = tmpl_xid.split(".", 1)
-                self.env["ir.model.data"].create(
+                self.env["ir.model.data"].sudo().create(
                     {
                         "name": id_,
                         "module": module,
@@ -289,7 +289,7 @@ class ProductProductRecordHandler(Component):
         )
         xid = self._make_attribute_value_xid(attr_column, orig_val)
         module, id_ = xid.split(".", 1)
-        self.env["ir.model.data"].create(
+        self.env["ir.model.data"].sudo().create(
             {
                 "name": id_,
                 "module": module,


### PR DESCRIPTION
By default, only users with "Access Rights" can create `ir.model.data` records.
We need sudo access on the creation for normal internal users.